### PR TITLE
Minor UI Enhancements and Fixes

### DIFF
--- a/projects/topomojo-launchpoint/src/app/app.component.html
+++ b/projects/topomojo-launchpoint/src/app/app.component.html
@@ -30,7 +30,7 @@
 
     <h1 *ngIf="state.error" class="text-danger">{{state.error | spaces}}</h1>
 
-    <div *ngIf="state.vms" class="flex-h z10">
+    <div *ngIf="state.vms" class="flex-h z10 vms">
 
       <div class="btn btn-lg" *ngFor="let vm of state.vms" (click)="open(vm)">
         <fa-icon [icon]="faTv"></fa-icon>

--- a/projects/topomojo-launchpoint/src/app/app.component.html
+++ b/projects/topomojo-launchpoint/src/app/app.component.html
@@ -13,9 +13,16 @@
         </button>
         <ng-container *ngIf="state.isDuring && !acting">
           <button class="btn" (click)="invite(state)">
-            <fa-icon [icon]="inviteCopied ? faClipboard : faShare"></fa-icon>
-            <span>Invite</span>
+            <fa-icon [icon]="faShare"></fa-icon>
+            <span>Generate Invite</span>
           </button>
+          <span *ngIf="generatedInviteCode" (click)="copyInvite()" style="margin: 8px 0px 8px 0px"
+            (mouseenter)="copyHovering=true" (mouseleave)="copyHovering=false">
+            Copy Link
+            <span *ngIf="inviteCopied || copyHovering" [class.text-success]="inviteCopied">
+              <fa-icon [icon]="inviteCopied ? faClipboardCheck : faClipboard" size="sm"></fa-icon>
+            </span>
+          </span>
           <app-confirm-button btnClass="btn" (confirm)="done(state)">
             <fa-icon [icon]="faTrash"></fa-icon>
             <span> End Session</span>

--- a/projects/topomojo-launchpoint/src/app/app.component.html
+++ b/projects/topomojo-launchpoint/src/app/app.component.html
@@ -16,10 +16,10 @@
             <fa-icon [icon]="inviteCopied ? faClipboard : faShare"></fa-icon>
             <span>Invite</span>
           </button>
-          <button class="btn" (click)="done(state)">
+          <app-confirm-button btnClass="btn" (confirm)="done(state)">
             <fa-icon [icon]="faTrash"></fa-icon>
             <span> End Session</span>
-          </button>
+          </app-confirm-button>
           <span>Session ends in {{timewindow.countdown | countdown}}</span>
         </ng-container>
         <app-spinner *ngIf="acting"></app-spinner>

--- a/projects/topomojo-launchpoint/src/app/app.component.scss
+++ b/projects/topomojo-launchpoint/src/app/app.component.scss
@@ -1,0 +1,4 @@
+.vms {
+    width: 50%;
+    margin: 0.5rem auto;
+}

--- a/projects/topomojo-launchpoint/src/app/app.module.ts
+++ b/projects/topomojo-launchpoint/src/app/app.module.ts
@@ -16,13 +16,15 @@ import { markedOptionsFactory } from './api.service';
 import { AppComponent } from './app.component';
 import { HttpInterceptorService } from './http-interceptor.service';
 import { SpacesPipe } from './spaces.pipe';
+import { ConfirmButtonComponent } from './utility/confirm-button/confirm-button.component';
 
 @NgModule({
   declarations: [
     AppComponent,
     SpinnerComponent,
     SpacesPipe,
-    CountdownPipe
+    CountdownPipe,
+    ConfirmButtonComponent
   ],
   imports: [
     BrowserModule,

--- a/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.html
+++ b/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.html
@@ -1,0 +1,15 @@
+<div class="btn-group flex-v">
+  <button [disabled]="confirming" [class]="btnClass" (click)="confirming=true" [disabled]="disabled">
+    <ng-content></ng-content>
+  </button>
+  <ng-container *ngIf="confirming">
+    <button [class]="btnClass" (click)="continue(true)">
+      <fa-icon [icon]="faCheck"></fa-icon>
+      <span>Confirm</span>
+    </button>
+    <button [class]="btnClass" (click)="continue(false)">
+      <fa-icon [icon]="faTimes"></fa-icon>
+      <span>Cancel</span>
+    </button>
+  </ng-container>
+</div>

--- a/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.scss
+++ b/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.scss
@@ -1,0 +1,3 @@
+button:disabled {
+    opacity: 0.65;
+}

--- a/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.spec.ts
+++ b/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmButtonComponent } from './confirm-button.component';
+
+describe('ConfirmButtonComponent', () => {
+  let component: ConfirmButtonComponent;
+  let fixture: ComponentFixture<ConfirmButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ConfirmButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.ts
+++ b/projects/topomojo-launchpoint/src/app/utility/confirm-button/confirm-button.component.ts
@@ -1,0 +1,28 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { faCheck, faTimes } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'app-confirm-button',
+  templateUrl: './confirm-button.component.html',
+  styleUrls: ['./confirm-button.component.scss']
+})
+export class ConfirmButtonComponent implements OnInit {
+  @Input() btnClass = 'btn';
+  @Input() disabled = false;
+  @Output() confirm = new EventEmitter<boolean>();
+  confirming = false;
+
+  faCheck = faCheck;
+  faTimes = faTimes;
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  continue(yes?: boolean): void {
+    if (!!yes) { this.confirm.emit(true); }
+    this.confirming = false;
+  }
+
+}

--- a/projects/topomojo-work/src/app/settings-editor/settings-editor.component.html
+++ b/projects/topomojo-work/src/app/settings-editor/settings-editor.component.html
@@ -57,10 +57,10 @@
 
     <div class="mt-2">
       <button class="btn btn-outline-secondary" (click)="enlistCode()">
-        <fa-icon [icon]="faUserCog"></fa-icon>
+        <fa-icon [icon]="copiedInvite ? faClipboardCheck : faUserCog"></fa-icon>
         <span>Generate invitation</span>
       </button>
-      <fa-icon *ngIf="inviteUrl" class="text-success ml-2" [icon]="faClipboardCheck"></fa-icon>
+      <app-clipspan class="mx-2">{{inviteUrl}}</app-clipspan>
     </div>
     <small>Invite collaborators by sharing an invitation url. (Invalidates existing invitation)</small>
 

--- a/projects/topomojo-work/src/app/settings-editor/settings-editor.component.ts
+++ b/projects/topomojo-work/src/app/settings-editor/settings-editor.component.ts
@@ -21,6 +21,7 @@ export class SettingsEditorComponent implements OnInit, OnChanges {
   @Input() workspace!: Workspace;
   form: FormGroup;
   inviteUrl = '';
+  copiedInvite = false;
   errors: any[] = [];
 
   faClipboardCheck = faClipboardCheck;
@@ -81,13 +82,17 @@ export class SettingsEditorComponent implements OnInit, OnChanges {
   }
 
   enlistCode(): void {
+    this.inviteUrl = '';
     this.api.generateInvitation(this.workspace.id).pipe(
       finalize(() => {})
     ).subscribe(
       result => {
         this.inviteUrl = `${this.config.absoluteUrl}enlist/${result.code}`;
         this.clipboard.copyToClipboard(this.inviteUrl);
-        timer(4000).subscribe(() => this.inviteUrl = '');
+        this.copiedInvite = true;
+        timer(4000).subscribe(() => {
+          this.copiedInvite = false;
+        });
       }
     );
   }


### PR DESCRIPTION
This PR has three commits which make very basic changes to `topomojo-launchpoint` regarding the invite guests feature:
- Limit width for vm list panel to avoid overlapping buttons
- Add confirmation step to "End Session" button
- Fix issue where Safari would not allow copying the generated invite link to clipboard outside the context of a user event based on a [new security feature](https://webkit.org/blog/10247/new-webkit-features-in-safari-13-1/).

There is also one commit that has a similar fix in `topomojo-work`:
- Fix same copy to clipboard issue in Safari for generating an invitation to a workspace