### PR TITLE
Dashboard UI for new observer role type

### DIFF
--- a/projects/topomojo-work/src/app/admin/admin.module.ts
+++ b/projects/topomojo-work/src/app/admin/admin.module.ts
@@ -18,6 +18,7 @@ import { ButtonsModule } from 'ngx-bootstrap/buttons';
 import { UserBrowserComponent } from './user-browser/user-browser.component';
 import { ApikeysComponent } from './apikeys/apikeys.component';
 import { LogViewerComponent } from './log-viewer/log-viewer.component';
+import { ObserveComponent } from './observe/observe.component';
 
 @NgModule({
   declarations: [
@@ -30,7 +31,8 @@ import { LogViewerComponent } from './log-viewer/log-viewer.component';
     TemplateDetailFormComponent,
     UserBrowserComponent,
     ApikeysComponent,
-    LogViewerComponent
+    LogViewerComponent,
+    ObserveComponent
   ],
   imports: [
     CommonModule,

--- a/projects/topomojo-work/src/app/admin/admin/admin.component.html
+++ b/projects/topomojo-work/src/app/admin/admin/admin.component.html
@@ -19,7 +19,7 @@
 
   <div [ngSwitch]="section" class="mb-4">
     <app-dashboard *ngSwitchCase="'dashboard' || ''"></app-dashboard>
-    <app-gamespace-browser *ngSwitchCase="'gamespaces'"></app-gamespace-browser>
+    <app-gamespace-browser *ngSwitchCase="'gamespaces'" [fullAdminView]="true"></app-gamespace-browser>
     <app-workspace-browser *ngSwitchCase="'workspaces'"></app-workspace-browser>
     <app-template-browser *ngSwitchCase="'templates'"></app-template-browser>
     <app-vm-browser *ngSwitchCase="'machines'"></app-vm-browser>

--- a/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.html
@@ -29,23 +29,23 @@
     <fa-icon [icon]="faSync"></fa-icon>
     <span>Refresh</span>
   </button>
-  <app-confirm-button btnClass="btn btn-outline-danger btn-sm" (confirm)="destroySelected()">
+  <app-confirm-button *ngIf="fullAdminView" btnClass="btn btn-outline-danger btn-sm" (confirm)="destroySelected()">
     <fa-icon [icon]="faTrash"></fa-icon>
     <span>Delete Selected</span>
   </app-confirm-button>
 </div>
 
-<div>
+<div *ngIf="fullAdminView">
   <button class="btn btn-light btn-sm mr-1" (click)="toggleAll()" aria-label="toggle selection for list">
     <fa-icon [icon]="selectAllValue ? faChecked : faUnChecked"></fa-icon>
   </button>
   <span><small>All</small></span>
 </div>
 
-<hr class="my-0"/>
+<hr class="my-0" [class]="!fullAdminView ? 'mt-2' : ''"/>
 
 <div *ngFor="let g of source$ | async; trackBy:trackById" class="row mb-1">
-  <div class="col-1">
+  <div class="col-1" *ngIf="fullAdminView">
     <button class="btn btn-light btn-sm" (click)="toggle(g)">
       <fa-icon [icon]="g.checked ? faChecked : faUnChecked"></fa-icon>
     </button>
@@ -54,16 +54,16 @@
     <small class="px-1" [class.pop-success]="!g.gameOver" [class.pop-dark]="g.gameOver">{{g.id | slice:0:8}}</small>&nbsp;
     <small>{{g.session.countdown | countdown}}</small>
   </div>
-  <div class="col-5">
+  <div [class]="fullAdminView ? 'col-5' : 'col-6'">
     <span>{{g.managerName}}</span>
     <small> &mdash; {{g.name}}</small>
   </div>
-  <div class="col-3">
+  <div class="col-3 d-flex justify-content-end">
     <button class="btn btn-outline-info btn-sm mx-1" (click)="view(g)">
       <fa-icon [icon]="faList"></fa-icon>
       <span>View</span>
     </button>
-    <app-confirm-button btnClass="btn btn-outline-danger btn-sm" (confirm)="destroy(g)">
+    <app-confirm-button *ngIf="fullAdminView" btnClass="btn btn-outline-danger btn-sm" (confirm)="destroy(g)">
       <fa-icon [icon]="faTrash"></fa-icon>
       <span>Destroy</span>
     </app-confirm-button>

--- a/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.html
@@ -75,7 +75,7 @@
           <span class="pop-info px-1">{{vm.name | untag}}</span>
         </div>
         <div class="col-6">
-          <app-vm-controller [vm]="vm"></app-vm-controller>
+          <app-vm-controller [vm]="vm" [fullAdminView]="fullAdminView"></app-vm-controller>
         </div>
       </div>
       <div>

--- a/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.ts
+++ b/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.ts
@@ -1,7 +1,7 @@
 // Copyright 2021 Carnegie Mellon University.
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { faCheck, faCheckSquare, faFilter, faList, faSearch, faSquare, faSync, faSyncAlt, faTintSlash, faTrash } from '@fortawesome/free-solid-svg-icons';
 import { asyncScheduler, BehaviorSubject, combineLatest, interval, merge, Observable, scheduled, Subject } from 'rxjs';
 import { debounceTime, filter, map, switchMap, tap, zipAll } from 'rxjs/operators';
@@ -15,6 +15,7 @@ import { VmService } from '../../api/vm.service';
   styleUrls: ['./gamespace-browser.component.scss']
 })
 export class GamespaceBrowserComponent implements OnInit {
+  @Input() fullAdminView: boolean = false;
   refresh$ = new BehaviorSubject<boolean>(true);
   source$: Observable<Gamespace[]>;
   source: Gamespace[] = [];

--- a/projects/topomojo-work/src/app/admin/observe/observe.component.html
+++ b/projects/topomojo-work/src/app/admin/observe/observe.component.html
@@ -1,0 +1,12 @@
+
+<div class="reader">
+
+  <small class="text-muted"></small>
+
+  <h1 class="mb-0 pb-0 mt-4">Observe Dashboard</h1>
+
+  <div class="mb-4">
+    <app-gamespace-browser [fullAdminView]="false"></app-gamespace-browser>
+  </div>
+  
+</div>

--- a/projects/topomojo-work/src/app/admin/observe/observe.component.spec.ts
+++ b/projects/topomojo-work/src/app/admin/observe/observe.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ObserveComponent } from './observe.component';
+
+describe('ObserveComponent', () => {
+  let component: ObserveComponent;
+  let fixture: ComponentFixture<ObserveComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ObserveComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ObserveComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/projects/topomojo-work/src/app/admin/observe/observe.component.ts
+++ b/projects/topomojo-work/src/app/admin/observe/observe.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-observe',
+  templateUrl: './observe.component.html',
+  styleUrls: ['./observe.component.scss']
+})
+export class ObserveComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.html
@@ -20,6 +20,10 @@
       <fa-icon [hidden]="filter!=='administrator'" [icon]="faFilter"></fa-icon>
       <span>admins</span>
     </button>
+    <button class="mr-1 btn btn-link text-info btn-sm" (click)="toggleFilter('observer')">
+      <fa-icon [hidden]="filter!=='observer'" [icon]="faFilter"></fa-icon>
+      <span>observers</span>
+    </button>
     <button class="mr-1 btn btn-link text-secondary btn-sm" (click)="toggleFilter('creator')">
       <fa-icon [hidden]="filter!=='creator'" [icon]="faFilter"></fa-icon>
       <span>creators</span>
@@ -78,6 +82,7 @@
           <label class="btn btn-outline-info btn-sm" btnRadio="user">User</label>
           <label class="btn btn-outline-info btn-sm" btnRadio="builder">Builder</label>
           <label class="btn btn-outline-info btn-sm" btnRadio="creator">Creator</label>
+          <label class="btn btn-outline-info btn-sm" btnRadio="observer">Observer</label>
           <label class="btn btn-outline-info btn-sm" btnRadio="administrator">Admin</label>
           <label class="btn btn-outline-info btn-sm" btnRadio="disabled">Disabled</label>
         </div>

--- a/projects/topomojo-work/src/app/api/gen/models.ts
+++ b/projects/topomojo-work/src/app/api/gen/models.ts
@@ -90,6 +90,7 @@ export interface ApiUser {
   scope: string;
   role: string;
   isAdmin: boolean;
+  isObserver: boolean;
   isCreator: boolean;
   isBuilder: boolean;
   workspaceLimit: number;

--- a/projects/topomojo-work/src/app/app-routing.module.ts
+++ b/projects/topomojo-work/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { AboutComponent } from './about/about.component';
 import { AdminGuard } from './admin.guard';
 import { AuthGuard } from './auth.guard';
+import { ObserverGuard } from './observer.guard';
 import { EnlistComponent } from './enlist/enlist.component';
 import { HomeComponent } from './home/home.component';
 import { LoginComponent } from './login/login.component';
@@ -13,6 +14,7 @@ import { OidcComponent } from './oidc/oidc.component';
 import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 import { WorkspaceEditorComponent } from './workspace-editor/workspace-editor.component';
 import { GamespaceComponent } from './gamespace/gamespace.component';
+import { ObserveComponent } from './admin/observe/observe.component';
 
 const routes: Routes = [
   { path: '', component: HomeComponent, pathMatch: 'full' },
@@ -25,6 +27,11 @@ const routes: Routes = [
     { path: 'mojo/:id/:slug', component: GamespaceComponent },
     { path: 'topo/:id', pathMatch: 'full', redirectTo: 'topo/:id/settings'},
     { path: 'topo/:id/:section', component: WorkspaceEditorComponent},
+    { 
+      path: 'observe', 
+      canLoad: [ObserverGuard], canActivate: [ObserverGuard], canActivateChild: [ObserverGuard],
+      component: ObserveComponent
+    },
     {
       path: 'admin',
       canLoad: [AdminGuard], canActivate: [AdminGuard], canActivateChild: [AdminGuard],

--- a/projects/topomojo-work/src/app/app.component.html
+++ b/projects/topomojo-work/src/app/app.component.html
@@ -17,6 +17,7 @@
     <a class="btn btn-outline-light btn-sm" [routerLink]="['/']">Home</a>
     <a class="btn btn-outline-light btn-sm ml-2" [routerLink]="['/about']">About</a>
     <button *ngIf="!!user && user.isAdmin" class="btn btn-outline-light btn-sm ml-2" [routerLink]="['/admin']">Admin</button>
+    <button *ngIf="!!user && user.isObserver && !user.isAdmin" class="btn btn-outline-light btn-sm ml-2" [routerLink]="['/observe']">Observe</button>
     <button *ngIf="!!user" class="btn btn-outline-light btn-sm ml-2" (click)="logout()">Logout</button>
   </div>
 </nav>

--- a/projects/topomojo-work/src/app/observer.guard.ts
+++ b/projects/topomojo-work/src/app/observer.guard.ts
@@ -1,0 +1,43 @@
+// Copyright 2021 Carnegie Mellon University.
+// Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
+
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanLoad, Route, Router, RouterStateSnapshot, UrlSegment, UrlTree } from '@angular/router';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { UserService } from './user.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ObserverGuard implements CanActivate, CanActivateChild, CanLoad {
+
+  constructor(
+    private userSvc: UserService,
+    private router: Router
+  ){
+
+  }
+  canActivate(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.validateRole();
+  }
+  canActivateChild(
+    childRoute: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.validateRole();
+  }
+  canLoad(
+    route: Route,
+    segments: UrlSegment[]): Observable<boolean | UrlTree> | Promise<boolean | UrlTree> | boolean | UrlTree {
+    return this.validateRole();
+  }
+
+  private validateRole(): Observable<boolean | UrlTree> {
+    return this.userSvc.user$.pipe(
+      map(u => u?.isObserver || false),
+      map(v => v ? v : this.router.parseUrl('/'))
+    );
+  }
+}

--- a/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.html
+++ b/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.html
@@ -57,7 +57,7 @@
         <fa-icon [icon]="faStepBackward"></fa-icon>
       </button>
 
-      <button class="btn btn-outline-dark" (click)="confirming=true"
+      <button *ngIf="fullAdminView" class="btn btn-outline-dark" (click)="confirming=true"
       aria-label="delete" tooltip="delete">
         <fa-icon [icon]="faTrash"></fa-icon>
       </button>

--- a/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.ts
+++ b/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.ts
@@ -18,6 +18,7 @@ import { ConfigService } from '../../config.service';
 export class VmControllerComponent implements OnInit, OnDestroy {
   @Input() template: (Template | TemplateSummary) = { id: '', name: '', workspaceId: ''};
   @Input() vm: Vm = {};
+  @Input() fullAdminView: boolean = false;
   task = '';
   confirming = false;
   vm$: Observable<Vm>;


### PR DESCRIPTION
Corresponding UI changes for https://github.com/cmu-sei/TopoMojo/pull/5

- New guarded route `/observe`
- New component for the Observe Dashboard
- Reuse of the gamespace browser component with modifications for admin-only controls