### PR TITLE
Change behavior for when to hide delete vm button

### DIFF
--- a/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/gamespace-browser/gamespace-browser.component.html
@@ -75,7 +75,7 @@
           <span class="pop-info px-1">{{vm.name | untag}}</span>
         </div>
         <div class="col-6">
-          <app-vm-controller [vm]="vm" [fullAdminView]="fullAdminView"></app-vm-controller>
+          <app-vm-controller [vm]="vm" [hideDelete]="!fullAdminView"></app-vm-controller>
         </div>
       </div>
       <div>

--- a/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.html
+++ b/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.html
@@ -57,7 +57,7 @@
         <fa-icon [icon]="faStepBackward"></fa-icon>
       </button>
 
-      <button *ngIf="fullAdminView" class="btn btn-outline-dark" (click)="confirming=true"
+      <button *ngIf="!hideDelete" class="btn btn-outline-dark" (click)="confirming=true"
       aria-label="delete" tooltip="delete">
         <fa-icon [icon]="faTrash"></fa-icon>
       </button>

--- a/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.ts
+++ b/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.ts
@@ -18,7 +18,7 @@ import { ConfigService } from '../../config.service';
 export class VmControllerComponent implements OnInit, OnDestroy {
   @Input() template: (Template | TemplateSummary) = { id: '', name: '', workspaceId: ''};
   @Input() vm: Vm = {};
-  @Input() fullAdminView: boolean = false;
+  @Input() hideDelete: boolean = false;
   task = '';
   confirming = false;
   vm$: Observable<Vm>;


### PR DESCRIPTION
In the recent observer mode feature, an observer can view a similar dashboard to the admin for listing gamespaces. They have more limited access however and should not see buttons for destroying gamespaces or deleting vms. In PR https://github.com/cmu-sei/topomojo-ui/pull/7, there was a change to only show the delete button for the admin in the dashboard, but that incorrectly hid the delete button where the vm controls component was reused elsewhere. 

This PR makes a small change to fix the bug so that the delete button is visible as normal everywhere except for the new observer dashboard where an observer will see gamespaces they have limited scoped access to. 

The VM Controller has field `hideDelete` which defaults to `false` and only is set to `true` for the observer dashboard. 