### PR TITLE
Fix initialize loading bug with new mapping

### DIFF
--- a/projects/topomojo-work/src/app/api/gen/vm.service.ts
+++ b/projects/topomojo-work/src/app/api/gen/vm.service.ts
@@ -50,8 +50,8 @@ export class GeneratedVmService extends GeneratedService {
   public deployTemplate(id: string): Observable<Vm> {
     return this.http.post<Vm>(this.conf.api + `/vm-template/${id}`, {});
   }
-  public initializeTemplate(id: string): Observable<Vm> {
-    return this.http.put<Vm>(this.conf.api + `/vm-template/${id}`, {});
+  public initializeTemplate(id: string): Observable<number> {
+    return this.http.put<number>(this.conf.api + `/vm-template/${id}`, {});
   }
   public reloadHost(host: string): Observable<any> {
     return this.http.post<any>(this.conf.api + `/pod/` + host, {});

--- a/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.ts
+++ b/projects/topomojo-work/src/app/utility/vm-controller/vm-controller.component.ts
@@ -6,7 +6,7 @@ import { Template, TemplateSummary, Vm, VmOperationTypeEnum } from '../../api/ge
 import { faCircleNotch, faSyncAlt, faCog, faBolt, faTv, faPlay, faStop, faSave, faStepBackward, faUndoAlt, faTrash, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { Observable, of, Subject, Subscription, timer } from 'rxjs';
 import { VmService } from '../../api/vm.service';
-import { catchError, finalize, switchMap, tap } from 'rxjs/operators';
+import { catchError, finalize, map, switchMap, tap } from 'rxjs/operators';
 import { NotificationService } from '../../notification.service';
 import { ConfigService } from '../../config.service';
 
@@ -86,7 +86,9 @@ export class VmControllerComponent implements OnInit, OnDestroy {
     switch (task) {
 
       case 'initialize':
-        q = this.api.initializeTemplate(this.template.id);
+        q = this.api.initializeTemplate(this.template.id).pipe(
+          map(i => ({...this.vm, task: {progress: i}} as Vm) )
+        );
         break;
 
       case 'deploy':


### PR DESCRIPTION
The bug was fixed by only modifying the UI, however there is a related change to the return type of `/vm-template/{id}` in the API: https://github.com/cmu-sei/TopoMojo/pull/9.

- The issue was that clicking the gear icon to "Initialize" would show the spinning load icon indefinitely and require a page refresh to see the updated state
- The initialize endpoint returns an integer, not a JSON object, so it needs to be mapped to a VM object to determine the task progress level based on VM properties and whether it should begin polling to check the readiness again