### PR TITLE
Color for observer role in Admin user list

### DIFF
--- a/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.html
@@ -20,7 +20,7 @@
       <fa-icon [hidden]="filter!=='administrator'" [icon]="faFilter"></fa-icon>
       <span>admins</span>
     </button>
-    <button class="mr-1 btn btn-link text-info btn-sm" (click)="toggleFilter('observer')">
+    <button class="mr-1 btn btn-link text-pink btn-sm" (click)="toggleFilter('observer')">
       <fa-icon [hidden]="filter!=='observer'" [icon]="faFilter"></fa-icon>
       <span>observers</span>
     </button>
@@ -49,6 +49,7 @@
   [class.pop-success]="user.role==='administrator'"
   [class.pop-secondary]="user.role==='creator'"
   [class.pop-warning]="user.role==='builder'"
+  [class.pop-pink]="user.role==='observer'"
   >
   <div class="col-8">
     <span class="text-secondary">{{user.name}}</span>
@@ -57,11 +58,8 @@
       <app-clipspan>{{user.id}}</app-clipspan>
     </small>
   </div>
-  <div class="col-1">
-    <small>{{user.whenCreated | shortdate}}</small>
-  </div>
-  <div class="col-3">
-
+  <div class="col-4 align-self-center text-right">
+    <small class="mr-2">{{user.whenCreated | shortdate}}</small>
     <button class="btn btn-outline-info btn-sm mx-1" (click)="view(user)">
       <fa-icon [icon]="faList"></fa-icon>
       <span>View</span>

--- a/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.scss
+++ b/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.scss
@@ -1,0 +1,11 @@
+
+// pink for Observer role
+.pop-pink {
+    background-color: #f3edf7;
+    border: #5b0094 solid 1px;
+    border-radius: 0.25rem;
+}
+
+.text-pink {
+    color: #5b0094;
+}


### PR DESCRIPTION
A new user role was added in PR https://github.com/cmu-sei/topomojo-ui/pull/7, but there was not a unique color given to this role type to help distinguish from other roles in the admin list.

- This minor change adds a new style (pink) for Observers in the admin list
- There is also a small style change to align buttons in each rows of this list