### PR TITLE
fixes losing focus on clipboard copy

### DIFF
--- a/projects/topomojo-mks/src/app/clipboard.service.ts
+++ b/projects/topomojo-mks/src/app/clipboard.service.ts
@@ -1,26 +1,13 @@
 // Copyright 2021 Carnegie Mellon University.
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
-import { Inject, Injectable } from '@angular/core';
-import { DOCUMENT } from '@angular/common';
+import { Injectable } from '@angular/core';
 
 @Injectable()
 export class ClipboardService {
+  constructor() {}
 
-    constructor(
-        @Inject(DOCUMENT) private dom: Document
-    ) { }
-
-    copyToClipboard(text: string): void {
-        const el = this.dom.createElement('textarea') as HTMLTextAreaElement;
-        el.style.position = 'fixed';
-        el.style.top = '-200';
-        el.style.left = '-200';
-        this.dom.body.appendChild(el);
-        el.value = text;
-        el.select();
-        this.dom.execCommand('copy');
-        this.dom.body.removeChild(el);
-    }
-
+  copyToClipboard(text: string): Promise<void> {
+    return navigator.clipboard.writeText(text);
+  }
 }


### PR DESCRIPTION
For Proxmox vms with automatic clipboard copy enabled, this bug prevents using the delete and backspace keys while text is highlighted as well as interuppting the CTRL+C, CTRL+V flow.