### PR TITLE
added post-paste clarification message to proxmox clipboard

### DIFF
--- a/projects/topomojo-mks/src/app/console/console.component.html
+++ b/projects/topomojo-mks/src/app/console/console.component.html
@@ -140,6 +140,10 @@
         </button>
       </div>
 
+      <div *ngIf="consoleSupportsFeatures?.pasteToClipboard && justPasted">
+        <p class="text-success text-center">Text copied to virtual machine's clipboard.</p>
+      </div>
+
       <textarea class="form-control" placeholder="Clipboard" rows="20" [(ngModel)]="cliptext"></textarea>
     </div>
   </div>

--- a/projects/topomojo-mks/src/app/console/console.component.scss
+++ b/projects/topomojo-mks/src/app/console/console.component.scss
@@ -113,3 +113,7 @@ label.auto-copy {
   vertical-align: text-top;
   margin-bottom: 18px;
 }
+
+.text-center {
+  text-align: center;
+}

--- a/projects/topomojo-mks/src/app/console/console.models.ts
+++ b/projects/topomojo-mks/src/app/console/console.models.ts
@@ -1,6 +1,7 @@
 export interface ConsoleSupportsFeatures {
     autoCopyVmSelection: boolean;
     virtualKeyboard: boolean;
+    pasteToClipboard: boolean;
 }
 
 export interface ConsoleOptions {

--- a/projects/topomojo-mks/src/app/console/services/mock-console.service.ts
+++ b/projects/topomojo-mks/src/app/console/services/mock-console.service.ts
@@ -39,7 +39,8 @@ export class MockConsoleService implements ConsoleService {
   getSupportedFeatures(): ConsoleSupportsFeatures {
     return {
       autoCopyVmSelection: false,
-      virtualKeyboard: false
+      virtualKeyboard: false,
+      pasteToClipboard: false
     }
   }
 

--- a/projects/topomojo-mks/src/app/console/services/novnc-console.service.ts
+++ b/projects/topomojo-mks/src/app/console/services/novnc-console.service.ts
@@ -71,7 +71,8 @@ export class NoVNCConsoleService implements ConsoleService {
   getSupportedFeatures(): ConsoleSupportsFeatures {
     return {
       autoCopyVmSelection: true,
-      virtualKeyboard: false
+      virtualKeyboard: false,
+      pasteToClipboard: true
     }
   }
 

--- a/projects/topomojo-mks/src/app/console/services/wmks-console.service.ts
+++ b/projects/topomojo-mks/src/app/console/services/wmks-console.service.ts
@@ -105,7 +105,8 @@ accepts keyboard input before clicking PASTE here.
   getSupportedFeatures(): ConsoleSupportsFeatures {
     return {
       autoCopyVmSelection: false,
-      virtualKeyboard: true
+      virtualKeyboard: true,
+      pasteToClipboard: false
     }
   }
 


### PR DESCRIPTION
Helps to differentiate hypervisors like proxmox where pasting copies the text to the virtual machine's clipboard, as opposed to writing the text to the user's cursor inside the vm.