### PR TITLE
Add user service account client ID ux

### DIFF
--- a/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.html
@@ -33,8 +33,12 @@
       <span>builders</span>
     </button>
     |
-    <button *ngFor="let s of scopes"
-      class="mr-1 btn btn-link text-dark btn-sm" (click)="toggleScope(s)">
+    <button class="mx-1 btn btn-link text-primary btn-sm" (click)="toggleServiceAccountFilter()">
+      <fa-icon [hidden]="!search.isServiceAccount" [icon]="faFilter"></fa-icon>
+      <span>service accounts</span>
+    </button>
+    |
+    <button *ngFor="let s of scopes" class="mr-1 btn btn-link text-dark btn-sm" (click)="toggleScope(s)">
       <fa-icon [hidden]="scope!==s" [icon]="faFilter"></fa-icon>
       <span>{{s}}</span>
     </button>
@@ -42,21 +46,23 @@
 </div>
 
 <app-pager [skip]="skip" [take]="take" [count]="count" (changed)="paged($event)"></app-pager>
-<hr class="mt-0 mb-2"/>
+<hr class="mt-0 mb-2" />
 
-<div *ngFor="let user of source$ | async; trackBy:trackById"
-  class="row mb-1"
-  [class.pop-success]="user.role==='administrator'"
-  [class.pop-secondary]="user.role==='creator'"
-  [class.pop-warning]="user.role==='builder'"
-  [class.pop-pink]="user.role==='observer'"
-  >
+<div *ngFor="let user of source$ | async; trackBy:trackById" class="row mb-1"
+  [class.pop-success]="user.role==='administrator'" [class.pop-secondary]="user.role==='creator'"
+  [class.pop-warning]="user.role==='builder'" [class.pop-pink]="user.role==='observer'">
   <div class="col-8">
     <span class="text-secondary">{{user.name}}</span>
-    <br/>
-    <small class="text-muted ml-4">
-      <app-clipspan>{{user.id}}</app-clipspan>
-    </small>
+    <br />
+    <div class="d-flex align-items-center my-1">
+      @if (user.serviceAccountClientId)
+      {
+      <div class="badge badge-sm badge-secondary mr-2">Service Account</div>
+      }
+      <small class="d-block text-muted">
+        <app-clipspan>{{user.id}}</app-clipspan>
+      </small>
+    </div>
   </div>
   <div class="col-4 align-self-center text-right">
     <small class="mr-2">{{user.whenCreated | shortdate}}</small>
@@ -73,67 +79,90 @@
   </div>
 
   <div *ngIf="viewed === user" class="col-12">
-
-      <div class="form-group bg-light">
-        <label for="role-input">Role</label><br/>
-        <div id="role-input" class="btn-group" btnRadioGroup [(ngModel)]="user.role" (click)="update(user)">
-          <label class="btn btn-outline-info btn-sm" btnRadio="user">User</label>
-          <label class="btn btn-outline-info btn-sm" btnRadio="builder">Builder</label>
-          <label class="btn btn-outline-info btn-sm" btnRadio="creator">Creator</label>
-          <label class="btn btn-outline-info btn-sm" btnRadio="observer">Observer</label>
-          <label class="btn btn-outline-info btn-sm" btnRadio="administrator">Admin</label>
-          <label class="btn btn-outline-info btn-sm" btnRadio="disabled">Disabled</label>
-        </div>
-        <small><pre>
+    @if (user.role === 'administrator' && user.serviceAccountClientId)
+    {
+    <alert type="danger" [dismissible]="true">
+      <strong>NOTE:</strong>
+      <div>
+        This user is currently configured as an administrator and has a service account client ID. For security reasons,
+        this is generally <strong>not advisable</strong>. We recommend that service account users have the
+        <strong>Observer</strong> role at maximum.
+      </div>
+    </alert>
+    }
+    <div class="form-group bg-light">
+      <label for="role-input">Role</label><br />
+      <div id="role-input" class="btn-group" btnRadioGroup [(ngModel)]="user.role" (click)="update(user)">
+        <label class="btn btn-outline-info btn-sm" btnRadio="user">User</label>
+        <label class="btn btn-outline-info btn-sm" btnRadio="builder">Builder</label>
+        <label class="btn btn-outline-info btn-sm" btnRadio="creator">Creator</label>
+        <label class="btn btn-outline-info btn-sm" btnRadio="observer">Observer</label>
+        <label class="btn btn-outline-info btn-sm" btnRadio="administrator">Admin</label>
+        <label class="btn btn-outline-info btn-sm" btnRadio="disabled">Disabled</label>
+      </div>
+      <small>
+        <pre>
           - Builder: bypasses some checks, like blocking bridge-net
           - Creator: bypasses workspace and template limits
-        </pre></small>
-      </div>
+        </pre>
+      </small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="name-input">Name</label>
-        <input id="name-input" class="form-control" type="text" [(ngModel)]="user.name" (change)="update(user)">
-        <small>for client "user" (regular users names' update from auth token)</small>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="name-input">Name</label>
+      <input id="name-input" class="form-control" type="text" [(ngModel)]="user.name" (change)="update(user)">
+      <small>for client "user" (regular users names' update from auth token)</small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="scope-input">Scope</label>
-        <input id="scope-input" class="form-control" type="text" [(ngModel)]="user.scope" (change)="update(user)">
-        <small>allowed gamespace audience list (space-delimited)</small><br/>
-        <small>users can only "play" workspaces with a matching audience tag</small>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="scope-input">Scope</label>
+      <input id="scope-input" class="form-control" type="text" [(ngModel)]="user.scope" (change)="update(user)">
+      <small>allowed gamespace audience list (space-delimited)</small><br />
+      <small>users can only "play" workspaces with a matching audience tag</small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="input-wslimit">Workspace Limit</label>
-        <input id="input-wslimit" class="form-control" type="number" [(ngModel)]="user.workspaceLimit" (change)="update(user)">
-        <small>max workspaces this user can manage</small>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="input-wslimit">Workspace Limit</label>
+      <input id="input-wslimit" class="form-control" type="number" [(ngModel)]="user.workspaceLimit"
+        (change)="update(user)">
+      <small>max workspaces this user can manage</small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="input-gslimit">Gamespace Limit</label>
-        <input id="input-gslimit" class="form-control" type="number" [(ngModel)]="user.gamespaceLimit" (change)="update(user)">
-        <small>max concurrent gamespaces allowed</small>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="input-gslimit">Gamespace Limit</label>
+      <input id="input-gslimit" class="form-control" type="number" [(ngModel)]="user.gamespaceLimit"
+        (change)="update(user)">
+      <small>max concurrent gamespaces allowed</small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="input-gsduration">Gamespace Max Duration</label>
-        <input id="input-gsduration" class="form-control" type="number" [(ngModel)]="user.gamespaceMaxMinutes" (change)="update(user)">
-        <small>max minutes allowed for a gamespace</small>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="input-gsduration">Gamespace Max Duration</label>
+      <input id="input-gsduration" class="form-control" type="number" [(ngModel)]="user.gamespaceMaxMinutes"
+        (change)="update(user)">
+      <small>max minutes allowed for a gamespace</small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="input-gscleanup">Gamespace Cleanup Grace time</label>
-        <input id="input-gscleanup" class="form-control" type="number" [(ngModel)]="user.gamespaceCleanupGraceMinutes" (change)="update(user)">
-        <small>grace minutes between expiration and teardown</small>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="input-gscleanup">Gamespace Cleanup Grace time</label>
+      <input id="input-gscleanup" class="form-control" type="number" [(ngModel)]="user.gamespaceCleanupGraceMinutes"
+        (change)="update(user)">
+      <small>grace minutes between expiration and teardown</small>
+    </div>
 
-      <div class="form-group bg-light">
-        <label class="mb-0" for="">ApiKeys</label>
-        <app-apikeys [id]="user.id"></app-apikeys>
-      </div>
+    <div class="form-group bg-light">
+      <label class="mb-0" for="input-serviceAccountClientId">Service Account Client Id</label>
+      <input id="input-serviceAccountClientId" class="form-control" [(ngModel)]="user.serviceAccountClientId"
+        (change)="update(user)">
+      <div><small>makes this a service account user; allows client credentials authorization</small></div>
+    </div>
+
+    <div class="form-group bg-light">
+      <label class="mb-0" for="">ApiKeys</label>
+      <app-apikeys [id]="user.id"></app-apikeys>
+    </div>
 
   </div>
 </div>
 
-<hr class="my-0"/>
+<hr class="my-0" />
 <app-pager [skip]="skip" [take]="take" [count]="count" (changed)="paged($event)"></app-pager>

--- a/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.ts
+++ b/projects/topomojo-work/src/app/admin/user-browser/user-browser.component.ts
@@ -10,10 +10,10 @@ import { ProfileService } from '../../api/profile.service';
 import { UserService } from '../../user.service';
 
 @Component({
-    selector: 'app-user-browser',
-    templateUrl: './user-browser.component.html',
-    styleUrls: ['./user-browser.component.scss'],
-    standalone: false
+  selector: 'app-user-browser',
+  templateUrl: './user-browser.component.html',
+  styleUrls: ['./user-browser.component.scss'],
+  standalone: false
 })
 export class UserBrowserComponent implements OnInit {
   refresh$ = new BehaviorSubject<boolean>(true);
@@ -22,7 +22,7 @@ export class UserBrowserComponent implements OnInit {
   selected: ApiUser[] = [];
   viewed: ApiUser | undefined = undefined;
   viewChange$ = new BehaviorSubject<ApiUser | undefined>(this.viewed);
-  search: UserSearch = { term: '', scope: '', take: 100};
+  search: UserSearch = { term: '', scope: '', take: 100 };
   skip = 0;
   take = 100;
   count = 0;
@@ -35,9 +35,7 @@ export class UserBrowserComponent implements OnInit {
   faSearch = faSearch;
   faFilter = faFilter;
 
-  constructor(
-    private api: ProfileService,
-  ) {
+  constructor(private api: ProfileService) {
     this.source$ = merge(
       this.refresh$,
       interval(60000)
@@ -83,6 +81,18 @@ export class UserBrowserComponent implements OnInit {
   toggleScope(scope: string): void {
     this.scope = this.scope !== scope ? scope : '';
     this.search.scope = this.scope;
+    this.skip = 0;
+    this.refresh();
+  }
+
+  toggleServiceAccountFilter() {
+    if (this.search.isServiceAccount) {
+      delete this.search.isServiceAccount;
+    }
+    else {
+      this.search.isServiceAccount = true;
+    }
+
     this.skip = 0;
     this.refresh();
   }

--- a/projects/topomojo-work/src/app/api/gen/models.ts
+++ b/projects/topomojo-work/src/app/api/gen/models.ts
@@ -98,6 +98,7 @@ export interface ApiUser {
   gamespaceLimit: number;
   gamespaceMaxMinutes: number;
   gamespaceCleanupGraceMinutes: number;
+  serviceAccountClientId?: string;
   whenCreated: string;
   apiKeys: ApiKey[];
 }
@@ -116,6 +117,7 @@ export interface ChangedUser {
   gamespaceLimit?: number;
   gamespaceMaxMinutes?: number;
   gamespaceCleanupGraceMinutes?: number;
+  serviceAccountClientId?: string;
 }
 
 export interface ApiKeyResult {
@@ -129,6 +131,7 @@ export interface ApiKey {
 }
 
 export interface UserSearch extends Search {
+  isServiceAccount?: boolean;
   scope: string;
 }
 

--- a/projects/topomojo-work/src/styles.scss
+++ b/projects/topomojo-work/src/styles.scss
@@ -13,7 +13,7 @@ $theme-colors: (
   "warning": #fdb515,
   "danger": #fa8304,
   "light": $gray-100,
-  "dark": $gray-800
+  "dark": $gray-800,
 );
 
 @import "../../../node_modules/bootstrap/scss/root";
@@ -35,7 +35,7 @@ $theme-colors: (
 @import "../../../node_modules/bootstrap/scss/card";
 // @import "../../../node_modules/bootstrap/scss/breadcrumb";
 // @import "../../../node_modules/bootstrap/scss/pagination";
-// @import "../../../node_modules/bootstrap/scss/badge";
+@import "../../../node_modules/bootstrap/scss/badge";
 // @import "../../../node_modules/bootstrap/scss/jumbotron";
 @import "../../../node_modules/bootstrap/scss/alert";
 @import "../../../node_modules/bootstrap/scss/progress";
@@ -55,7 +55,7 @@ $theme-colors: (
   .pop-#{$color} {
     background-color: theme-color-level($color, -11);
     border: $value solid 1px;
-    border-radius: .25rem;
+    border-radius: 0.25rem;
   }
 }
 
@@ -80,7 +80,11 @@ $theme-colors: (
 fa-icon + span {
   margin-left: 4px;
 }
-h1,h2,h3,h4,h5 {
+h1,
+h2,
+h3,
+h4,
+h5 {
   font-weight: 300;
 }
 .spacer {
@@ -91,21 +95,21 @@ h1,h2,h3,h4,h5 {
   max-width: 600px;
 }
 .label {
-  padding: .375rem .25rem !important;
+  padding: 0.375rem 0.25rem !important;
   min-width: 240px;
   margin: 0;
 }
 .form-group {
   padding: 1.5rem;
-  margin-bottom: .5rem;
-  border-radius: .25rem;
+  margin-bottom: 0.5rem;
+  border-radius: 0.25rem;
 }
 .form-group > .form-control {
-  font-size: .875rem!important;
-  padding: .25rem .5rem !important;
+  font-size: 0.875rem !important;
+  padding: 0.25rem 0.5rem !important;
 }
 .form-group > label {
-  font-size: .875rem !important;
+  font-size: 0.875rem !important;
 }
 .untack > svg {
   transform: rotate(45deg);
@@ -114,15 +118,18 @@ h1,h2,h3,h4,h5 {
   margin: 6rem auto;
 }
 .alert {
-  margin-bottom: .25rem !important;
+  margin-bottom: 0.25rem !important;
 }
 app-spinner svg {
-  rect,path {
+  rect,
+  path {
     fill: theme-color("primary");
   }
 }
 
-.editor-cursor { min-width: 2px; }
+.editor-cursor {
+  min-width: 2px;
+}
 .editor-selection {
   min-width: 8px;
   opacity: 0.3;
@@ -133,8 +140,12 @@ app-spinner svg {
   top: -3px;
   margin-left: -3px;
 }
-.editor-cursor-between { margin-left: -1px; }
-.editor-online { color: white; }
+.editor-cursor-between {
+  margin-left: -1px;
+}
+.editor-online {
+  color: white;
+}
 .editor-offline {
   color: black;
   opacity: 0.6;
@@ -144,8 +155,8 @@ app-spinner svg {
   color: lightgray;
   font-size: 1.2rem;
   font-family: monospace;
-  padding: .25rem;
-  border-radius: .25rem;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
   border: lightgray 2px solid;
   width: 100px;
 }


### PR DESCRIPTION
- User service account client IDs can now be managed in Admin -> Users
- Users with a defined service account client ID get a badge to distinguish them from other users
- Added a new filter that displays only service account users
- Displays a warning if a user has both the Admin role and a service account client ID, as we don't recommend that combination (Observer is generally what you want).