### PR TITLE
Restructuring hamburger location in sidebar

### DIFF
--- a/projects/topomojo-work/src/app/app-layout/app-layout.component.html
+++ b/projects/topomojo-work/src/app/app-layout/app-layout.component.html
@@ -29,18 +29,22 @@
     <div #sidebarContainer>
 
         <section
-                class="sidebar sidebar-body bg-light"
-                [class.sidebar-out]="open"
-                [class.sidebar-in]="!open">
+            class="sidebar sidebar-body bg-light"
+            [class.sidebar-out]="open"
+            [class.sidebar-in]="!open">
 
-            <div [hidden]="open"
-                class="text-secondary m-2 sidebar-toggle"
-                (click)="toggleSidebar()">
-            <fa-icon [icon]="faBars" size="lg"></fa-icon>
+            <div class="d-flex align-items-center p-2">
+                <button class="btn btn-link p-0 text-secondary sidebar-toggle"
+                        type="button"
+                        (click)="toggleSidebar()"
+                        aria-label="Toggle sidebar">
+                <fa-icon [icon]="faBars" size="lg"></fa-icon>
+                </button>
             </div>
 
             <app-workspace-browser [hidden]="!open"></app-workspace-browser>
         </section>
+
 
         <div class="sidebar sidebar-footer bg-light align-items-center"
      tabindex="0"
@@ -78,13 +82,6 @@
         <fa-icon [icon]="faThumbtack"
                  [class.untack]="!pinned"
                  size="lg"></fa-icon>
-      </button>
-
-      <button class="btn btn-link p-0 text-secondary"
-              type="button"
-              (click)="closeSidebar()"
-              aria-label="Close sidebar">
-        <fa-icon [icon]="faClose" size="lg"></fa-icon>
       </button>
     </div>
 

--- a/projects/topomojo-work/src/app/app-layout/app-layout.component.scss
+++ b/projects/topomojo-work/src/app/app-layout/app-layout.component.scss
@@ -94,4 +94,6 @@ footer {
   border-radius: 0.375rem;
   margin-left: 0;
   cursor: pointer;
+  flex: 0 0 auto !important;
+  align-self: flex-start;
 }


### PR DESCRIPTION
In this PR, I made the hamburger button to be persistent when the sidebar is open/closed. So, this will enable the user to open/close the sidebar by just clicking this button, instead of having to use the X, which was also removed in this PR.