### PR TITLE
Improve janitor cleanup report with sortable table and workspace links

### DIFF
--- a/projects/topomojo-work/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/topomojo-work/src/app/admin/dashboard/dashboard.component.html
@@ -63,27 +63,7 @@
   <hr/>
 
   <div class="row mb-2 janitor-header align-items-center">
-    <div class="col-2 px-4">
-      <button
-        type="button"
-        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
-        (click)="sortJanitor('id')"
-        placement="right"
-        container="body"
-        triggers="hover focus"
-        [tooltip]="'Sort by workspace/gamespace ID.'"
-        aria-label="Sort by workspace/gamespace ID."
-      >
-        <span>ID</span>
-        <fa-icon
-          class="ml-1"
-          *ngIf="janitorSort.column === 'id'"
-          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
-        </fa-icon>
-      </button>
-    </div>
-
-    <div class="col-2 px-4">
+    <div class="col-3 px-2">
       <button
         type="button"
         class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -103,7 +83,7 @@
       </button>
     </div>
 
-    <div class="col-3 px-4">
+    <div class="col-4 px-2">
       <button
         type="button"
         class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -123,7 +103,7 @@
       </button>
     </div>
 
-    <div class="col-2 px-4">
+    <div class="col-2 px-2">
       <button
         type="button"
         class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -143,7 +123,7 @@
       </button>
     </div>
 
-    <div class="col-1 px-4">
+    <div class="col-1 px-2">
       <button
         type="button"
         class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -163,7 +143,7 @@
       </button>
     </div>
 
-    <div class="col-2 px-4">
+    <div class="col-2 px-2">
       <button
         type="button"
         class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -185,27 +165,27 @@
   </div>
 
   <div *ngFor="let r of janitorReports; trackBy:trackByReportId" class="row mb-1 align-items-center">
-    <div class="col-2 px-4">
-      <small class="text-muted text-break font-monospace">{{ r.id }}</small>
-    </div>
-
-    <div class="col-2 px-4">
+    <div class="col-3 px-2">
       <span class="text-break">{{ r.reason }}</span>
     </div>
 
-    <div class="col-3 px-4">
-      <span class="text-break">{{ r.name }}</span>
+    <div class="col-4 px-2">
+      <a [routerLink]="['/topo', r.id]" class="text-secondary">{{ r.name }}</a>
+      <br/>
+      <small class="text-muted d-block text-break">
+        <app-clipspan>{{ r.id }}</app-clipspan>
+      </small>
     </div>
 
-    <div class="col-2 px-4">
+    <div class="col-2 px-2">
       <span class="text-break">{{ r.ownerName }}</span>
     </div>
 
-    <div class="col-1 px-4">
+    <div class="col-1 px-2">
       <span>{{ r.vmCount }}</span>
     </div>
 
-    <div class="col-2 px-4">
+    <div class="col-2 px-2">
       <small class="text-muted">{{ r.age | date:'short' }}</small>
     </div>
   </div>

--- a/projects/topomojo-work/src/app/admin/dashboard/dashboard.component.html
+++ b/projects/topomojo-work/src/app/admin/dashboard/dashboard.component.html
@@ -59,8 +59,154 @@
   </button>
 </div>
 
-<p *ngFor="let r of janitorResult | async" class="mb-1">
-  <span>{{r.reason}}</span>,
-  <span>{{r.name}}</span>,
-  <span>{{r.age}}</span>
-</p>
+<div *ngIf="janitorReports.length > 0" class="mt-3">
+  <hr/>
+
+  <div class="row mb-2 janitor-header align-items-center">
+    <div class="col-2 px-4">
+      <button
+        type="button"
+        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+        (click)="sortJanitor('id')"
+        placement="right"
+        container="body"
+        triggers="hover focus"
+        [tooltip]="'Sort by workspace/gamespace ID.'"
+        aria-label="Sort by workspace/gamespace ID."
+      >
+        <span>ID</span>
+        <fa-icon
+          class="ml-1"
+          *ngIf="janitorSort.column === 'id'"
+          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
+        </fa-icon>
+      </button>
+    </div>
+
+    <div class="col-2 px-4">
+      <button
+        type="button"
+        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+        (click)="sortJanitor('reason')"
+        placement="right"
+        container="body"
+        triggers="hover focus"
+        [tooltip]="'Sort by cleanup reason.'"
+        aria-label="Sort by cleanup reason."
+      >
+        <span>Reason</span>
+        <fa-icon
+          class="ml-1"
+          *ngIf="janitorSort.column === 'reason'"
+          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
+        </fa-icon>
+      </button>
+    </div>
+
+    <div class="col-3 px-4">
+      <button
+        type="button"
+        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+        (click)="sortJanitor('name')"
+        placement="right"
+        container="body"
+        triggers="hover focus"
+        [tooltip]="'Sort by workspace name.'"
+        aria-label="Sort by workspace name."
+      >
+        <span>Name</span>
+        <fa-icon
+          class="ml-1"
+          *ngIf="janitorSort.column === 'name'"
+          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
+        </fa-icon>
+      </button>
+    </div>
+
+    <div class="col-2 px-4">
+      <button
+        type="button"
+        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+        (click)="sortJanitor('owner')"
+        placement="right"
+        container="body"
+        triggers="hover focus"
+        [tooltip]="'Sort by workspace owner.'"
+        aria-label="Sort by workspace owner."
+      >
+        <span>Owner</span>
+        <fa-icon
+          class="ml-1"
+          *ngIf="janitorSort.column === 'owner'"
+          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
+        </fa-icon>
+      </button>
+    </div>
+
+    <div class="col-1 px-4">
+      <button
+        type="button"
+        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+        (click)="sortJanitor('vmCount')"
+        placement="right"
+        container="body"
+        triggers="hover focus"
+        [tooltip]="'Sort by VM count.'"
+        aria-label="Sort by VM count."
+      >
+        <span>VMs</span>
+        <fa-icon
+          class="ml-1"
+          *ngIf="janitorSort.column === 'vmCount'"
+          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
+        </fa-icon>
+      </button>
+    </div>
+
+    <div class="col-2 px-4">
+      <button
+        type="button"
+        class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+        (click)="sortJanitor('age')"
+        placement="right"
+        container="body"
+        triggers="hover focus"
+        [tooltip]="'Sort by last activity date.'"
+        aria-label="Sort by last activity date."
+      >
+        <span>Last Activity</span>
+        <fa-icon
+          class="ml-1"
+          *ngIf="janitorSort.column === 'age'"
+          [icon]="janitorSort.ascending ? faSortUp : faSortDown">
+        </fa-icon>
+      </button>
+    </div>
+  </div>
+
+  <div *ngFor="let r of janitorReports; trackBy:trackByReportId" class="row mb-1 align-items-center">
+    <div class="col-2 px-4">
+      <small class="text-muted text-break font-monospace">{{ r.id }}</small>
+    </div>
+
+    <div class="col-2 px-4">
+      <span class="text-break">{{ r.reason }}</span>
+    </div>
+
+    <div class="col-3 px-4">
+      <span class="text-break">{{ r.name }}</span>
+    </div>
+
+    <div class="col-2 px-4">
+      <span class="text-break">{{ r.ownerName }}</span>
+    </div>
+
+    <div class="col-1 px-4">
+      <span>{{ r.vmCount }}</span>
+    </div>
+
+    <div class="col-2 px-4">
+      <small class="text-muted">{{ r.age | date:'short' }}</small>
+    </div>
+  </div>
+</div>

--- a/projects/topomojo-work/src/app/admin/dashboard/dashboard.component.ts
+++ b/projects/topomojo-work/src/app/admin/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
 import { Component, OnInit } from '@angular/core';
-import { faMailBulk, faPaperPlane, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { faMailBulk, faPaperPlane, faInfoCircle, faSortUp, faSortDown } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, interval, merge, Observable } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { AdminService } from '../../api/admin.service';
@@ -19,11 +19,15 @@ export class DashboardComponent implements OnInit {
   connections!: Observable<CachedConnection[]>;
   importResult!: Observable<string[]>;
   janitorResult!: Observable<JanitorReport[]>;
+  janitorReports: JanitorReport[] = [];
+  janitorSort = { column: 'age', ascending: false };
   announcement = '';
   exportIds = '';
 
   faSend = faPaperPlane;
   faInfoCircle = faInfoCircle;
+  faSortUp = faSortUp;
+  faSortDown = faSortDown;
 
   constructor(
     private api: AdminService
@@ -69,5 +73,55 @@ export class DashboardComponent implements OnInit {
 
   cleanup(): void {
     this.janitorResult = this.api.cleanup();
+    this.janitorResult.subscribe(reports => {
+      this.janitorReports = reports;
+      this.sortJanitorReports();
+    });
+  }
+
+  sortJanitor(column: string): void {
+    if (this.janitorSort.column === column) {
+      this.janitorSort.ascending = !this.janitorSort.ascending;
+    } else {
+      this.janitorSort.column = column;
+      this.janitorSort.ascending = true;
+    }
+    this.sortJanitorReports();
+  }
+
+  private sortJanitorReports(): void {
+    const column = this.janitorSort.column;
+    const ascending = this.janitorSort.ascending;
+
+    this.janitorReports.sort((a, b) => {
+      let comparison = 0;
+
+      switch (column) {
+        case 'id':
+          comparison = (a.id || '').localeCompare(b.id || '');
+          break;
+        case 'reason':
+          comparison = (a.reason || '').localeCompare(b.reason || '');
+          break;
+        case 'name':
+          comparison = (a.name || '').localeCompare(b.name || '');
+          break;
+        case 'age':
+          comparison = new Date(a.age || 0).getTime() - new Date(b.age || 0).getTime();
+          break;
+        case 'owner':
+          comparison = (a.ownerName || '').localeCompare(b.ownerName || '');
+          break;
+        case 'vmCount':
+          comparison = (a.vmCount || 0) - (b.vmCount || 0);
+          break;
+      }
+
+      return ascending ? comparison : -comparison;
+    });
+  }
+
+  trackByReportId(index: number, item: JanitorReport): string {
+    return item.id || index.toString();
   }
 }

--- a/projects/topomojo-work/src/app/api/gen/models.ts
+++ b/projects/topomojo-work/src/app/api/gen/models.ts
@@ -420,6 +420,8 @@ export interface JanitorReport {
   name?: string;
   reason?: string;
   age?: string;
+  ownerName?: string;
+  vmCount?: number;
 }
 
 export interface CachedConnection {


### PR DESCRIPTION
**Summary**

  - Replace plain-text cleanup report with a sortable table (Reason, Name, Owner, VMs, Last Activity)
  - Workspace name links to the workspace editor (/topo/:id)
  - Workspace ID shown below name with copy-to-clipboard support via app-clipspan
  - Add ownerName and vmCount to the JanitorReport model to match API changes