### PR TITLE
Increase reader max-width to 1000px for better table display

### DIFF
--- a/projects/topomojo-work/src/styles.scss
+++ b/projects/topomojo-work/src/styles.scss
@@ -64,9 +64,8 @@ $theme-colors: (
   margin: 0 auto;
 }
 .reader {
-  max-width: 800px;
+  max-width: 1000px;
   margin: 0 auto;
-  // margin: auto;
 }
 .fs-15 {
   font-size: 1.5em;


### PR DESCRIPTION
- Change .reader max-width from 800px to 1000px
- Provides 25% more width for admin tables and content
- Still maintains readability while reducing horizontal scrolling