### PR TITLE
Enhance machines table with workspace links and orphaned VM indicators

### DIFF
--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -102,7 +102,32 @@
   </div>
 
   <div class="col-5 px-4">
-    <small class="text-muted text-break">{{ vm.groupName }}</small>
+    <ng-container *ngIf="parseGroupName(vm.groupName) as parsed">
+      <ng-container *ngIf="parsed.type === 'workspace'">
+        <a [routerLink]="['/topo', parsed.id]" class="text-secondary">{{ parsed.name }}</a>
+        <br/>
+        <small class="text-muted d-block text-break">
+          <app-clipspan>{{ parsed.id }}</app-clipspan>
+        </small>
+      </ng-container>
+      <ng-container *ngIf="parsed.type === 'gamespace'">
+        <a [routerLink]="['/mojo', parsed.id]" class="text-secondary">{{ parsed.name }}</a>
+        <br/>
+        <small class="text-muted d-block text-break">
+          <app-clipspan>{{ parsed.id }}</app-clipspan>
+        </small>
+      </ng-container>
+      <ng-container *ngIf="parsed.type === 'orphaned'">
+        <span class="text-warning">
+          <fa-icon [icon]="faInfoCircle" class="mr-1"></fa-icon>
+          Orphaned
+        </span>
+        <br/>
+        <small class="text-muted d-block text-break">
+          <app-clipspan>{{ parsed.id }}</app-clipspan>
+        </small>
+      </ng-container>
+    </ng-container>
   </div>
 
   <div class="col-2 px-4">

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
@@ -67,6 +67,29 @@ export class VmBrowserComponent implements OnInit {
     return vm.id || '';
   }
 
+  parseGroupName(groupName?: string): { type: 'workspace' | 'gamespace' | 'orphaned', name: string, id: string } {
+    if (!groupName) return { type: 'orphaned', name: 'Unknown', id: '' };
+
+    const parts = groupName.split('#');
+    if (parts.length !== 2) return { type: 'orphaned', name: groupName, id: '' };
+
+    const [prefix, id] = parts;
+
+    if (prefix === '__orphaned') {
+      return { type: 'orphaned', name: 'Orphaned', id };
+    }
+
+    if (prefix.startsWith('workspace: ')) {
+      return { type: 'workspace', name: prefix.substring(11), id };
+    }
+
+    if (prefix.startsWith('gamespace: ')) {
+      return { type: 'gamespace', name: prefix.substring(11), id };
+    }
+
+    return { type: 'orphaned', name: prefix, id };
+  }
+
   sortBy(field: 'name' | 'group' | 'host'): void {
     if (this.sortField === field) {
       this.sortAscending = !this.sortAscending;

--- a/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.html
+++ b/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.html
@@ -26,5 +26,10 @@
   </div>
 </ng-container>
 
+<div *ngIf="isAdmin && !game.isActive && orphanedVmCount > 0" class="alert alert-warning my-3">
+  <strong>Admin Notice:</strong> This gamespace has ended, but {{orphanedVmCount}} VM{{orphanedVmCount === 1 ? '' : 's'}} still exist{{orphanedVmCount === 1 ? 's' : ''}} in the hypervisor.
+  View or delete from the <a routerLink="/admin/machines" class="alert-link">Machines</a> page.
+</div>
+
 <h3 *ngIf="hasQuestions">Challenge Questions</h3>
 <app-gamespace-quiz [state]="game"></app-gamespace-quiz>

--- a/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
+++ b/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
@@ -1,12 +1,14 @@
 // Copyright 2021 Carnegie Mellon University.
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnChanges } from '@angular/core';
 import { faBolt, faTrash, faTv } from '@fortawesome/free-solid-svg-icons';
 import { finalize } from 'rxjs/operators';
 import { GamespaceService } from '../api/gamespace.service';
 import { GameState, VmState } from '../api/gen/models';
 import { ConfigService } from '../config.service';
+import { UserService } from '../user.service';
+import { VmService } from '../api/vm.service';
 
 @Component({
   selector: 'app-gamespace-state',
@@ -14,20 +16,41 @@ import { ConfigService } from '../config.service';
   styleUrls: ['./gamespace-state.component.scss'],
   standalone: false
 })
-export class GamespaceStateComponent implements OnInit {
+export class GamespaceStateComponent implements OnInit, OnChanges {
   @Input() game!: GameState;
   deploying = false;
   faBolt = faBolt;
   faTrash = faTrash;
   faTv = faTv;
   protected hasQuestions = false;
+  isAdmin = false;
+  orphanedVmCount = 0;
 
   constructor(
     private api: GamespaceService,
-    private conf: ConfigService
+    private conf: ConfigService,
+    private userSvc: UserService,
+    private vmApi: VmService
   ) { }
 
   ngOnInit(): void {
+    this.userSvc.user$.subscribe(u => {
+      this.isAdmin = u?.isAdmin || false;
+      this.checkOrphanedVms();
+    });
+  }
+
+  ngOnChanges(): void {
+    this.checkOrphanedVms();
+  }
+
+  private checkOrphanedVms(): void {
+    if (this.isAdmin && !this.game.isActive && this.game.id) {
+      // Check if VMs exist for this ended gamespace
+      this.vmApi.list(this.game.id).subscribe(vms => {
+        this.orphanedVmCount = vms.length;
+      });
+    }
   }
 
   start(): void {


### PR DESCRIPTION
- Add clickable workspace/gamespace links in machines table with copyable GUIDs
- Show warning icon for orphaned VMs (VMs without associated workspace/gamespace)
- Add admin warning banner on ended gamespace pages when VMs still exist
- Parse groupName field to extract workspace/gamespace IDs for routing
- Use clipspan component for GUID copying consistent with janitor report