### PR TITLE
Add VM power state column and address feedback

### DIFF
--- a/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.html
+++ b/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.html
@@ -23,26 +23,20 @@
         <fa-icon [icon]="trace===i ? faCaretDown : faCaretRight"></fa-icon>
       </button>
 
-      <button
-        type="button"
-        class="btn btn-sm btn-link text-muted p-0 mr-2"
-        (click)="copy(ex, i)"
-        (mouseenter)="hovering = i"
-        (mouseleave)="hovering = -1"
-        aria-label="Copy log entry to clipboard"
-      >
-        <fa-icon [icon]="copied === i ? faClipboardCheck : faClipboard" [class.text-success]="copied === i"></fa-icon>
-      </button>
-
       <div class="flex-grow-1">
         <div class="d-flex align-items-center flex-wrap">
           <small class="text-muted mr-2">{{ ex.timestamp }}</small>
-
-          <span
-            class="ml-1 text-muted"
-            aria-label="This tab shows error entries only. Expand an entry to see the stack trace."
+          <button
+            *ngIf="trace===i"
+            type="button"
+            class="btn btn-sm btn-link text-muted p-0"
+            (click)="copy(ex, i)"
+            (mouseenter)="hovering = i"
+            (mouseleave)="hovering = -1"
+            aria-label="Copy log entry to clipboard"
           >
-          </span>
+            <fa-icon [icon]="copied === i ? faClipboardCheck : faClipboard" [class.text-success]="copied === i"></fa-icon>
+          </button>
         </div>
 
         <div class="mt-1">

--- a/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.html
+++ b/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.html
@@ -23,6 +23,17 @@
         <fa-icon [icon]="trace===i ? faCaretDown : faCaretRight"></fa-icon>
       </button>
 
+      <button
+        type="button"
+        class="btn btn-sm btn-link text-muted p-0 mr-2"
+        (click)="copy(ex, i)"
+        (mouseenter)="hovering = i"
+        (mouseleave)="hovering = -1"
+        aria-label="Copy log entry to clipboard"
+      >
+        <fa-icon [icon]="copied === i ? faClipboardCheck : faClipboard" [class.text-success]="copied === i"></fa-icon>
+      </button>
+
       <div class="flex-grow-1">
         <div class="d-flex align-items-center flex-wrap">
           <small class="text-muted mr-2">{{ ex.timestamp }}</small>

--- a/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.ts
+++ b/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.ts
@@ -20,6 +20,7 @@ export class LogViewerComponent implements OnInit {
   copied = -1;
   hovering = -1;
   log$: Observable<any>;
+  private copyTimer?: ReturnType<typeof setTimeout>;
   faCaretDown = faCaretDown;
   faCaretRight = faCaretRight;
   faInfoCircle = faInfoCircle;
@@ -48,8 +49,19 @@ export class LogViewerComponent implements OnInit {
 
   copy(ex: any, i: number): void {
     const text = `${ex.timestamp}\n${ex.message}\n\n${ex.stackTrace || ''}`;
-    navigator.clipboard.writeText(text);
-    this.copied = i;
-    setTimeout(() => this.copied = -1, 4000);
+
+    // Cancel previous timer if clicking again
+    if (this.copyTimer) {
+      clearTimeout(this.copyTimer);
+    }
+
+    navigator.clipboard.writeText(text)
+      .then(() => {
+        this.copied = i;
+        this.copyTimer = setTimeout(() => this.copied = -1, 4000);
+      })
+      .catch(() => {
+        // Copy failed, don't show success indicator
+      });
   }
 }

--- a/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.ts
+++ b/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.ts
@@ -2,7 +2,7 @@
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
 import { Component, OnInit } from '@angular/core';
-import { faCaretDown, faCaretRight, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
+import { faCaretDown, faCaretRight, faInfoCircle, faClipboard, faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, interval, merge, Observable } from 'rxjs';
 import { switchMap, tap } from 'rxjs/operators';
 import { AdminService } from '../../api/admin.service';
@@ -17,10 +17,14 @@ export class LogViewerComponent implements OnInit {
   refresh$ = new BehaviorSubject<boolean>(true);
   since = '';
   trace = -1;
+  copied = -1;
+  hovering = -1;
   log$: Observable<any>;
   faCaretDown = faCaretDown;
   faCaretRight = faCaretRight;
   faInfoCircle = faInfoCircle;
+  faClipboard = faClipboard;
+  faClipboardCheck = faClipboardCheck;
 
   constructor(
     api: AdminService
@@ -39,6 +43,13 @@ export class LogViewerComponent implements OnInit {
   }
 
   select(i: number): void {
-    this.trace = i;
+    this.trace = this.trace === i ? -1 : i;
+  }
+
+  copy(ex: any, i: number): void {
+    const text = `${ex.timestamp}\n${ex.message}\n\n${ex.stackTrace || ''}`;
+    navigator.clipboard.writeText(text);
+    this.copied = i;
+    setTimeout(() => this.copied = -1, 4000);
   }
 }

--- a/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.ts
+++ b/projects/topomojo-work/src/app/admin/log-viewer/log-viewer.component.ts
@@ -47,10 +47,13 @@ export class LogViewerComponent implements OnInit {
     this.trace = this.trace === i ? -1 : i;
   }
 
-  copy(ex: any, i: number): void {
-    const text = `${ex.timestamp}\n${ex.message}\n\n${ex.stackTrace || ''}`;
+  getLogText(ex: any): string {
+    return `${ex.timestamp}\n${ex.message}\n\n${ex.stackTrace || ''}`;
+  }
 
-    // Cancel previous timer if clicking again
+  copy(ex: any, i: number): void {
+    const text = this.getLogText(ex);
+
     if (this.copyTimer) {
       clearTimeout(this.copyTimer);
     }

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -122,31 +122,29 @@
   </div>
 
   <div class="col-3 px-4">
-    <ng-container *ngIf="parseGroupName(vm.groupName) as parsed">
-      <ng-container *ngIf="parsed.type === 'workspace'">
-        <a [routerLink]="['/topo', parsed.id]" class="text-secondary">{{ parsed.name }}</a>
-        <br/>
-        <small class="text-muted d-block text-break">
-          <app-clipspan>{{ parsed.id }}</app-clipspan>
-        </small>
-      </ng-container>
-      <ng-container *ngIf="parsed.type === 'gamespace'">
-        <a [routerLink]="['/mojo', parsed.id]" class="text-secondary">{{ parsed.name }}</a>
-        <br/>
-        <small class="text-muted d-block text-break">
-          <app-clipspan>{{ parsed.id }}</app-clipspan>
-        </small>
-      </ng-container>
-      <ng-container *ngIf="parsed.type === 'orphaned'">
-        <span class="text-warning">
-          <fa-icon [icon]="faInfoCircle" class="mr-1"></fa-icon>
-          Orphaned
-        </span>
-        <br/>
-        <small class="text-muted d-block text-break">
-          <app-clipspan>{{ parsed.id }}</app-clipspan>
-        </small>
-      </ng-container>
+    <ng-container *ngIf="vm.parsedGroup.type === 'workspace'">
+      <a [routerLink]="['/topo', vm.parsedGroup.id]" class="text-secondary">{{ vm.parsedGroup.name }}</a>
+      <br/>
+      <small class="text-muted d-block text-break">
+        <app-clipspan>{{ vm.parsedGroup.id }}</app-clipspan>
+      </small>
+    </ng-container>
+    <ng-container *ngIf="vm.parsedGroup.type === 'gamespace'">
+      <a [routerLink]="['/mojo', vm.parsedGroup.id]" class="text-secondary">{{ vm.parsedGroup.name }}</a>
+      <br/>
+      <small class="text-muted d-block text-break">
+        <app-clipspan>{{ vm.parsedGroup.id }}</app-clipspan>
+      </small>
+    </ng-container>
+    <ng-container *ngIf="vm.parsedGroup.type === 'orphaned'">
+      <span class="text-warning">
+        <fa-icon [icon]="faInfoCircle" class="mr-1"></fa-icon>
+        Orphaned
+      </span>
+      <br/>
+      <small class="text-muted d-block text-break">
+        <app-clipspan>{{ vm.parsedGroup.id }}</app-clipspan>
+      </small>
     </ng-container>
   </div>
 

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -150,9 +150,9 @@
 
   <div class="col-1 px-4">
     <small [ngClass]="{
-      'text-success': vm.state === 'running',
-      'text-muted': vm.state === 'off',
-      'text-warning': vm.state === 'suspended'
+      'text-success': vm.state === VmStateEnum.running,
+      'text-muted': vm.state === VmStateEnum.off,
+      'text-warning': vm.state === VmStateEnum.suspended
     }">
       {{ vm.state || 'unknown' }}
     </small>

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -125,14 +125,14 @@
     <ng-container *ngIf="vm.parsedGroup.type === 'workspace'">
       <a [routerLink]="['/topo', vm.parsedGroup.id]" class="text-secondary">{{ vm.parsedGroup.name }}</a>
       <br/>
-      <small class="text-muted d-block text-break">
+      <small class="text-muted d-block text-nowrap">
         <app-clipspan>{{ vm.parsedGroup.id }}</app-clipspan>
       </small>
     </ng-container>
     <ng-container *ngIf="vm.parsedGroup.type === 'gamespace'">
       <a [routerLink]="['/mojo', vm.parsedGroup.id]" class="text-secondary">{{ vm.parsedGroup.name }}</a>
       <br/>
-      <small class="text-muted d-block text-break">
+      <small class="text-muted d-block text-nowrap">
         <app-clipspan>{{ vm.parsedGroup.id }}</app-clipspan>
       </small>
     </ng-container>
@@ -142,7 +142,7 @@
         Orphaned
       </span>
       <br/>
-      <small class="text-muted d-block text-break">
+      <small class="text-muted d-block text-nowrap">
         <app-clipspan>{{ vm.parsedGroup.id }}</app-clipspan>
       </small>
     </ng-container>

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -55,7 +55,7 @@
     </button>
   </div>
 
-  <div class="col-3 px-4">
+  <div class="col-4 px-4">
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -75,7 +75,7 @@
     </button>
   </div>
 
-  <div class="col-3 px-4">
+  <div class="col-2 px-4">
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -121,7 +121,7 @@
     <span class="text-break">{{ vm.name }}</span>
   </div>
 
-  <div class="col-3 px-4">
+  <div class="col-4 px-4">
     <ng-container *ngIf="vm.parsedGroup.type === 'workspace'">
       <a [routerLink]="['/topo', vm.parsedGroup.id]" class="text-secondary">{{ vm.parsedGroup.name }}</a>
       <br/>
@@ -148,7 +148,7 @@
     </ng-container>
   </div>
 
-  <div class="col-3 px-4">
+  <div class="col-2 px-4">
     <small [ngClass]="{
       'text-success': vm.state === 'running',
       'text-muted': vm.state === 'off',

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -3,7 +3,7 @@
 
 <h4>Machines</h4>
 <div class="text-muted mb-2">
-  View all VMs TopoMojo is tracking and the gamespaces/workspaces they belong to. This is a read-only listing (you can’t control
+  View all VMs TopoMojo is tracking and the gamespaces/workspaces they belong to. This is a read-only listing (you can't control
   VMs from here). Use Search to find VMs by name, group, host, or paste a gamespace GUID.
 </div>
 
@@ -35,7 +35,7 @@
 <hr/>
 
 <div class="row mb-2 vm-header align-items-center">
-  <div class="col-5 px-4">
+  <div class="col-4 px-4">
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -43,8 +43,8 @@
       placement="right"
       container="body"
       triggers="hover focus"
-      [tooltip]="'Sort by the VM’s name.'"
-      aria-label="Sort by the VM’s name."
+      tooltip="Sort by VM name."
+      aria-label="Sort by VM name."
     >
       <span>Machine Name</span>
       <fa-icon
@@ -55,7 +55,7 @@
     </button>
   </div>
 
-  <div class="col-5 px-4">
+  <div class="col-4 px-4">
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -63,8 +63,8 @@
       placement="right"
       container="body"
       triggers="hover focus"
-      [tooltip]="'Sort by the gamespace or group this VM belongs to.'"
-      aria-label="Sort by the gamespace or group this VM belongs to."
+      tooltip="Sort by gamespace or group."
+      aria-label="Sort by gamespace or group."
     >
       <span>Gamespace / Group</span>
       <fa-icon
@@ -79,12 +79,32 @@
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
+      (click)="sortBy('state')"
+      placement="right"
+      container="body"
+      triggers="hover focus"
+      tooltip="Sort by VM power state."
+      aria-label="Sort by VM power state."
+    >
+      <span>State</span>
+      <fa-icon
+        class="ml-1"
+        *ngIf="sortField === 'state'"
+        [icon]="sortAscending ? faSortUp : faSortDown">
+      </fa-icon>
+    </button>
+  </div>
+
+  <div class="col-2 px-4">
+    <button
+      type="button"
+      class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
       (click)="sortBy('host')"
       placement="right"
       container="body"
       triggers="hover focus"
-      [tooltip]="'Sort by the hypervisor host currently running this VM.'"
-      aria-label="Sort by the hypervisor host currently running this VM."
+      tooltip="Sort by hypervisor host."
+      aria-label="Sort by hypervisor host."
     >
       <span>Host</span>
       <fa-icon
@@ -97,12 +117,22 @@
 </div>
 
 <div *ngFor="let vm of source$ | async; trackBy:trackById" class="row mb-1 align-items-center">
-  <div class="col-5 px-4">
+  <div class="col-4 px-4">
     <span class="text-break">{{ vm.name }}</span>
   </div>
 
-  <div class="col-5 px-4">
+  <div class="col-4 px-4">
     <small class="text-muted text-break">{{ vm.groupName }}</small>
+  </div>
+
+  <div class="col-2 px-4">
+    <small [ngClass]="{
+      'text-success': vm.state === 'running',
+      'text-muted': vm.state === 'off',
+      'text-warning': vm.state === 'suspended'
+    }">
+      {{ vm.state || 'unknown' }}
+    </small>
   </div>
 
   <div class="col-2 px-4">

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.html
@@ -35,7 +35,7 @@
 <hr/>
 
 <div class="row mb-2 vm-header align-items-center">
-  <div class="col-4 px-4">
+  <div class="col-5 px-4">
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -75,7 +75,7 @@
     </button>
   </div>
 
-  <div class="col-2 px-4">
+  <div class="col-1 px-4">
     <button
       type="button"
       class="btn btn-link p-0 sort-header header-label text-primary d-inline-flex align-items-center"
@@ -117,7 +117,7 @@
 </div>
 
 <div *ngFor="let vm of source$ | async; trackBy:trackById" class="row mb-1 align-items-center">
-  <div class="col-4 px-4">
+  <div class="col-5 px-4">
     <span class="text-break">{{ vm.name }}</span>
   </div>
 
@@ -148,7 +148,7 @@
     </ng-container>
   </div>
 
-  <div class="col-2 px-4">
+  <div class="col-1 px-4">
     <small [ngClass]="{
       'text-success': vm.state === 'running',
       'text-muted': vm.state === 'off',

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
@@ -26,7 +26,7 @@ export class VmBrowserComponent implements OnInit {
   faInfoCircle = faInfoCircle;
 
   sortAscending = true;
-  sortField: 'name' | 'group' | 'host' = 'name';
+  sortField: 'name' | 'group' | 'state' | 'host' = 'name';
 
   constructor(private api: VmService) {
     this.source$ = this.refresh$.pipe(
@@ -67,7 +67,7 @@ export class VmBrowserComponent implements OnInit {
     return vm.id || '';
   }
 
-  sortBy(field: 'name' | 'group' | 'host'): void {
+  sortBy(field: 'name' | 'group' | 'state' | 'host'): void {
     if (this.sortField === field) {
       this.sortAscending = !this.sortAscending;
     } else {
@@ -86,6 +86,8 @@ export class VmBrowserComponent implements OnInit {
       switch (this.sortField) {
         case 'group':
           return (vm.groupName || '').toLowerCase();
+        case 'state':
+          return (vm.state || '').toLowerCase();
         case 'host':
           return (hostShort(vm) || '').toLowerCase();
         default:

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
@@ -8,6 +8,10 @@ import { debounceTime, switchMap, tap, map } from 'rxjs/operators';
 import { Search, Vm } from '../../api/gen/models';
 import { VmService } from '../../api/vm.service';
 
+interface VmWithParsedGroup extends Vm {
+  parsedGroup: { type: 'workspace' | 'gamespace' | 'orphaned', name: string, id: string };
+}
+
 @Component({
   selector: 'app-vm-browser',
   templateUrl: './vm-browser.component.html',
@@ -16,8 +20,8 @@ import { VmService } from '../../api/vm.service';
 })
 export class VmBrowserComponent implements OnInit {
   refresh$ = new BehaviorSubject<boolean>(true);
-  source$: Observable<Vm[]>;
-  source: Vm[] = [];
+  source$: Observable<VmWithParsedGroup[]>;
+  source: VmWithParsedGroup[] = [];
   search: Search = { term: '', take: 100 };
 
   faSearch = faSearch;
@@ -33,6 +37,10 @@ export class VmBrowserComponent implements OnInit {
       debounceTime(300),
       switchMap(() => this.api.list('')),
       map(vms => this.filterVms(vms, this.search.term)),
+      map(vms => vms.map(vm => ({
+        ...vm,
+        parsedGroup: this.parseGroupName(vm.groupName)
+      }))),
       tap(r => {
         this.source = r;
         this.applySort();
@@ -63,7 +71,7 @@ export class VmBrowserComponent implements OnInit {
     });
   }
 
-  trackById(index: number, vm: Vm): string {
+  trackById(index: number, vm: VmWithParsedGroup): string {
     return vm.id || '';
   }
 

--- a/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
+++ b/projects/topomojo-work/src/app/admin/vm-browser/vm-browser.component.ts
@@ -5,7 +5,7 @@ import { Component, OnInit } from '@angular/core';
 import { faSearch, faSortUp, faSortDown, faInfoCircle } from '@fortawesome/free-solid-svg-icons';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { debounceTime, switchMap, tap, map } from 'rxjs/operators';
-import { Search, Vm } from '../../api/gen/models';
+import { Search, Vm, VmStateEnum } from '../../api/gen/models';
 import { VmService } from '../../api/vm.service';
 
 interface VmWithParsedGroup extends Vm {
@@ -28,6 +28,7 @@ export class VmBrowserComponent implements OnInit {
   faSortUp = faSortUp;
   faSortDown = faSortDown;
   faInfoCircle = faInfoCircle;
+  VmStateEnum = VmStateEnum;
 
   sortAscending = true;
   sortField: 'name' | 'group' | 'state' | 'host' = 'name';

--- a/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.html
+++ b/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.html
@@ -27,7 +27,7 @@
 </ng-container>
 
 <div *ngIf="isAdmin && !game.isActive && orphanedVmCount > 0" class="alert alert-warning my-3">
-  <strong>Admin Notice:</strong> This gamespace has ended, but {{orphanedVmCount}} VM{{orphanedVmCount === 1 ? '' : 's'}} still exist{{orphanedVmCount === 1 ? 's' : ''}} in the hypervisor.
+  <strong>Admin Notice:</strong> This gamespace has ended, but {{ orphanedVmCount | i18nPlural: { '=1': '1 VM still exists', 'other': '# VMs still exist' } }} in the hypervisor.
   View on the <a routerLink="/admin/machines" class="alert-link">Machines</a> page or delete from the <a routerLink="/admin/gamespaces" class="alert-link">Gamespaces</a> page.
 </div>
 

--- a/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
+++ b/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
@@ -4,7 +4,7 @@
 import { Component, Input, OnInit, OnChanges, OnDestroy } from '@angular/core';
 import { faBolt, faTrash, faTv } from '@fortawesome/free-solid-svg-icons';
 import { finalize, switchMap, filter, distinctUntilChanged, takeUntil } from 'rxjs/operators';
-import { Subject, combineLatest } from 'rxjs';
+import { Subject, BehaviorSubject, combineLatest } from 'rxjs';
 import { GamespaceService } from '../api/gamespace.service';
 import { GameState, VmState } from '../api/gen/models';
 import { ConfigService } from '../config.service';
@@ -28,7 +28,7 @@ export class GamespaceStateComponent implements OnInit, OnChanges, OnDestroy {
   orphanedVmCount = 0;
 
   private destroy$ = new Subject<void>();
-  private gameChange$ = new Subject<GameState>();
+  private gameChange$ = new BehaviorSubject<GameState | null>(null);
 
   constructor(
     private api: GamespaceService,
@@ -44,13 +44,13 @@ export class GamespaceStateComponent implements OnInit, OnChanges, OnDestroy {
       this.gameChange$
     ]).pipe(
       filter(([user, game]) =>
-        (user?.isAdmin || false) && !game.isActive && !!game.id
+        !!game && (user?.isAdmin || false) && !game.isActive && !!game.id
       ),
       distinctUntilChanged(
         ([prevUser, prevGame], [currUser, currGame]) =>
-          prevGame.id === currUser.id && prevGame.isActive === currGame.isActive
+          prevGame?.id === currGame?.id && prevGame?.isActive === currGame?.isActive
       ),
-      switchMap(([user, game]) => this.vmApi.list(game.id!)),
+      switchMap(([user, game]) => this.vmApi.list(game!.id!)),
       takeUntil(this.destroy$)
     ).subscribe(vms => {
       this.orphanedVmCount = vms.length;

--- a/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
+++ b/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, Input, OnInit, OnChanges, OnDestroy } from '@angular/core';
 import { faBolt, faTrash, faTv } from '@fortawesome/free-solid-svg-icons';
-import { finalize, switchMap, filter, distinctUntilChanged } from 'rxjs/operators';
+import { finalize, switchMap, filter, distinctUntilChanged, takeUntil } from 'rxjs/operators';
 import { Subject, combineLatest } from 'rxjs';
 import { GamespaceService } from '../api/gamespace.service';
 import { GameState, VmState } from '../api/gen/models';
@@ -48,15 +48,18 @@ export class GamespaceStateComponent implements OnInit, OnChanges, OnDestroy {
       ),
       distinctUntilChanged(
         ([prevUser, prevGame], [currUser, currGame]) =>
-          prevGame.id === currGame.id && prevGame.isActive === currGame.isActive
+          prevGame.id === currUser.id && prevGame.isActive === currGame.isActive
       ),
-      switchMap(([user, game]) => this.vmApi.list(game.id!))
+      switchMap(([user, game]) => this.vmApi.list(game.id!)),
+      takeUntil(this.destroy$)
     ).subscribe(vms => {
       this.orphanedVmCount = vms.length;
     });
 
     // Track admin status separately for template
-    this.userSvc.user$.subscribe(u => {
+    this.userSvc.user$.pipe(
+      takeUntil(this.destroy$)
+    ).subscribe(u => {
       this.isAdmin = u?.isAdmin || false;
     });
   }

--- a/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
+++ b/projects/topomojo-work/src/app/gamespace-state/gamespace-state.component.ts
@@ -1,9 +1,10 @@
 // Copyright 2021 Carnegie Mellon University.
 // Released under a 3 Clause BSD-style license. See LICENSE.md in the project root.
 
-import { Component, Input, OnInit, OnChanges } from '@angular/core';
+import { Component, Input, OnInit, OnChanges, OnDestroy } from '@angular/core';
 import { faBolt, faTrash, faTv } from '@fortawesome/free-solid-svg-icons';
-import { finalize } from 'rxjs/operators';
+import { finalize, switchMap, filter, distinctUntilChanged } from 'rxjs/operators';
+import { Subject, combineLatest } from 'rxjs';
 import { GamespaceService } from '../api/gamespace.service';
 import { GameState, VmState } from '../api/gen/models';
 import { ConfigService } from '../config.service';
@@ -16,7 +17,7 @@ import { VmService } from '../api/vm.service';
   styleUrls: ['./gamespace-state.component.scss'],
   standalone: false
 })
-export class GamespaceStateComponent implements OnInit, OnChanges {
+export class GamespaceStateComponent implements OnInit, OnChanges, OnDestroy {
   @Input() game!: GameState;
   deploying = false;
   faBolt = faBolt;
@@ -26,6 +27,9 @@ export class GamespaceStateComponent implements OnInit, OnChanges {
   isAdmin = false;
   orphanedVmCount = 0;
 
+  private destroy$ = new Subject<void>();
+  private gameChange$ = new Subject<GameState>();
+
   constructor(
     private api: GamespaceService,
     private conf: ConfigService,
@@ -34,23 +38,36 @@ export class GamespaceStateComponent implements OnInit, OnChanges {
   ) { }
 
   ngOnInit(): void {
+    // Combine user admin status with game changes to fetch orphaned VMs
+    combineLatest([
+      this.userSvc.user$,
+      this.gameChange$
+    ]).pipe(
+      filter(([user, game]) =>
+        (user?.isAdmin || false) && !game.isActive && !!game.id
+      ),
+      distinctUntilChanged(
+        ([prevUser, prevGame], [currUser, currGame]) =>
+          prevGame.id === currGame.id && prevGame.isActive === currGame.isActive
+      ),
+      switchMap(([user, game]) => this.vmApi.list(game.id!))
+    ).subscribe(vms => {
+      this.orphanedVmCount = vms.length;
+    });
+
+    // Track admin status separately for template
     this.userSvc.user$.subscribe(u => {
       this.isAdmin = u?.isAdmin || false;
-      this.checkOrphanedVms();
     });
   }
 
   ngOnChanges(): void {
-    this.checkOrphanedVms();
+    this.gameChange$.next(this.game);
   }
 
-  private checkOrphanedVms(): void {
-    if (this.isAdmin && !this.game.isActive && this.game.id) {
-      // Check if VMs exist for this ended gamespace
-      this.vmApi.list(this.game.id).subscribe(vms => {
-        this.orphanedVmCount = vms.length;
-      });
-    }
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 
   start(): void {


### PR DESCRIPTION
  Adds power state column to admin machines table and addresses review feedback from PR #56.

  ### Changes

  **Power state column:**
  - Display VM power state (running/off/suspended) with color coding
  - Sortable by state
  - Column layout: 4-4-2-2 (Name, Gamespace/Group, State, Host)

  **Performance fixes:**
  - Pre-compute `parseGroupName` in pipeline instead of on every change detection cycle
  - Fix `user$` subscription leak (added `OnDestroy`)
  - Prevent orphaned-VM fetch races with `switchMap` + `distinctUntilChanged`
  - Fix init-order fragility using observable pipeline

  **UI polish:**
  - Use `i18nPlural` pipe for pluralization
  - Prevent GUID wrapping with `text-nowrap`

  Fixes must-fix issues #2 (subscription leak) and #3 (race conditions) from PR #56 review.