### PR TITLE
Add Penalty field to challenge question editor

### DIFF
--- a/projects/topomojo-work/src/app/challenge-editor/challenge-form.service.ts
+++ b/projects/topomojo-work/src/app/challenge-editor/challenge-form.service.ts
@@ -78,9 +78,9 @@ export class ChallengeFormService {
       answer: [q?.answer, Validators.required],
       example: [q?.example],
       hint: [q?.hint],
-      penalty: [q?.penalty || 0, Validators.pattern(/\d*/)],
+      penalty: [q?.penalty || 0, [Validators.min(0)]],
       grader: [q?.grader || 'match'],
-      weight: [q?.weight || 0, Validators.pattern(/\d*/)],
+      weight: [q?.weight || 0, [Validators.min(0)]],
       hidden: [q?.hidden || false]
     });
   }

--- a/projects/topomojo-work/src/app/challenge-editor/question-form/question-form.component.html
+++ b/projects/topomojo-work/src/app/challenge-editor/question-form/question-form.component.html
@@ -151,6 +151,7 @@
             class="form-control"
             formControlName="weight"
             placeholder=""
+            min="0"
             (mouseenter)="infotip=5"
           >
         </div>
@@ -166,6 +167,7 @@
             class="form-control"
             formControlName="penalty"
             placeholder="0"
+            min="0"
             (mouseenter)="infotip=6"
           >
         </div>
@@ -195,6 +197,9 @@
           <small *ngIf="infotip===6">
             Percentage deducted per wrong attempt (cumulative). <strong>MUST use same scale as weight</strong> (<code>0-1</code> or <code>0-100</code>).
             Example: weight 0.5, penalty 0.1 → wrong once = 40 pts, wrong twice = 30 pts, correct first try = 50 pts.
+          </small>
+          <small class="text-warning" *ngIf="q.get('penalty')?.value > q.get('weight')?.value && q.get('weight')?.value > 0">
+            ⚠️ Penalty exceeds weight - may result in negative scores after multiple wrong attempts.
           </small>
         </div>
       </div>

--- a/projects/topomojo-work/src/app/challenge-editor/question-form/question-form.component.html
+++ b/projects/topomojo-work/src/app/challenge-editor/question-form/question-form.component.html
@@ -151,6 +151,22 @@
             class="form-control"
             formControlName="weight"
             placeholder=""
+            (mouseenter)="infotip=5"
+          >
+        </div>
+
+        <div class="form-group col-2 py-0">
+          <label for="penalty-input{{vindex}}.{{this.index}}.{{i}}" class="mb-0 d-flex align-items-center">
+            Penalty
+          </label>
+
+          <input
+            id="penalty-input{{vindex}}.{{this.index}}.{{i}}"
+            type="number"
+            class="form-control"
+            formControlName="penalty"
+            placeholder="0"
+            (mouseenter)="infotip=6"
           >
         </div>
 
@@ -175,6 +191,10 @@
           <small *ngIf="infotip===5">
             Percentage of total for this question. Value should be between <code>0 and 1</code>, or <code>0 and 100</code>, inclusive.
             0 values are calculated evenly.
+          </small>
+          <small *ngIf="infotip===6">
+            Point deduction per wrong submission. Subtracted from weight when question is finally answered correctly.
+            Value should match weight scale (0-1 or 0-100).
           </small>
         </div>
       </div>

--- a/projects/topomojo-work/src/app/challenge-editor/question-form/question-form.component.html
+++ b/projects/topomojo-work/src/app/challenge-editor/question-form/question-form.component.html
@@ -189,12 +189,12 @@
           <small *ngIf="infotip===3">MatchAll &mdash; match all of the pipe-delimited answers, regardless of order</small>
           <small *ngIf="infotip===4">MatchAlpha &mdash; match answer exactly after stripping any symbols</small>
           <small *ngIf="infotip===5">
-            Percentage of total for this question. Value should be between <code>0 and 1</code>, or <code>0 and 100</code>, inclusive.
-            0 values are calculated evenly.
+            Percentage of challenge total for this question. Use <code>0-1</code> (e.g., 0.5 = 50%) or <code>0-100</code> (e.g., 50 = 50%).
+            Leave at 0 to distribute weight evenly across all questions.
           </small>
           <small *ngIf="infotip===6">
-            Point deduction per wrong submission. Subtracted from weight when question is finally answered correctly.
-            Value should match weight scale (0-1 or 0-100).
+            Percentage deducted per wrong attempt (cumulative). <strong>MUST use same scale as weight</strong> (<code>0-1</code> or <code>0-100</code>).
+            Example: weight 0.5, penalty 0.1 → wrong once = 40 pts, wrong twice = 30 pts, correct first try = 50 pts.
           </small>
         </div>
       </div>

--- a/projects/topomojo-work/src/app/gamespace-quiz/gamespace-quiz.component.html
+++ b/projects/topomojo-work/src/app/gamespace-quiz/gamespace-quiz.component.html
@@ -14,7 +14,7 @@
 
     <div *ngFor="let q of section.questions; let i=index" class="form-group p-2 my-3" [class.pop-info]="!q.isGraded"
       [class.pop-success]="q.isGraded && q.isCorrect" [class.pop-warning]="q.isGraded && !q.isCorrect">
-      <label>{{i+1}}. ({{q.weight}}) {{q.text}}</label>
+      <label>{{i+1}}. ({{(q.weight * challengeProgress.maxPoints) | number:'1.0-0'}}) {{q.text}}</label>
       <input class="form-control" [readonly]="q.isCorrect" [(ngModel)]="q.answer">
       <small [hidden]="!q.example">Example answer: {{q.example}}</small>
     </div>

--- a/projects/topomojo-work/src/app/gamespace-quiz/gamespace-quiz.component.html
+++ b/projects/topomojo-work/src/app/gamespace-quiz/gamespace-quiz.component.html
@@ -31,7 +31,7 @@
     <div class="alert alert-info my-3">
       <div class="d-flex align-items-center justify-content-between">
         <div>
-          <strong>Final Score:</strong> {{challengeProgress.score}} of {{challengeProgress.maxPoints}}
+          <strong>Final Score:</strong> {{challengeProgress.score | number:'1.0-2'}} of {{challengeProgress.maxPoints}}
         </div>
         <div>
           <strong>Attempts Used:</strong> {{challengeProgress.attempts}} of {{challengeProgress.maxAttempts}}
@@ -72,7 +72,7 @@
         <strong>
           Score:
         </strong>
-        {{state.challenge.score}} of {{state.challenge.maxPoints}}
+        {{state.challenge.score | number:'1.0-2'}} of {{state.challenge.maxPoints}}
       </div>
     </div>
   </ng-container>

--- a/projects/topomojo-work/src/app/gamespace-quiz/gamespace-quiz.component.html
+++ b/projects/topomojo-work/src/app/gamespace-quiz/gamespace-quiz.component.html
@@ -26,6 +26,20 @@
     </app-confirm-button>
   </div>
 
+  <!-- Final score display after game ends -->
+  <ng-container *ngIf="state.gameOver || !state.session.isDuring">
+    <div class="alert alert-info my-3">
+      <div class="d-flex align-items-center justify-content-between">
+        <div>
+          <strong>Final Score:</strong> {{challengeProgress.score}} of {{challengeProgress.maxPoints}}
+        </div>
+        <div>
+          <strong>Attempts Used:</strong> {{challengeProgress.attempts}} of {{challengeProgress.maxAttempts}}
+        </div>
+      </div>
+    </div>
+  </ng-container>
+
   <ng-container *ngIf="!state.gameOver && state.session.isDuring">
     <alert type="info" class="d-block my-3"
       *ngIf="challengeProgress.nextSectionPreReqThisSection || challengeProgress.nextSectionPreReqTotal">


### PR DESCRIPTION
## Summary
- Add Penalty field to challenge question editor UI
- Add tooltip explaining penalty scale requirements and cumulative behavior
- Add form validation (min=0, penalty>weight warning)
- Display question weights as points instead of normalized values
- Show final score after all attempts exhausted
- Format scores with 1-2 decimal places for precision

## Changes
1. **question-form.component.html**: 
   - Added penalty input field with tooltip
   - Added min=0 validation
   - Added warning when penalty > weight
2. **challenge-form.service.ts**: Added Validators.min(0) for weight/penalty
3. **gamespace-quiz.component.html**:
   - Display weights as points: `(weight × maxPoints)`
   - Show final score display after game ends
   - Format scores with `number:'1.0-2'` pipe

## Penalty Behavior
Penalty is **cumulative** (Moodle-style): deducted for each wrong attempt.
- Example: weight 0.5, penalty 0.1
  - Wrong once = 40 pts (0.5 - 0.1×1)
  - Wrong twice = 30 pts (0.5 - 0.1×2)
  - Correct first try = 50 pts

## Testing
Tested with weight=0.01, penalty=0.001, maxPoints=100:
- Question displays as "(1)" not "(0.01)"
- Final score shows "99.8 of 100" with decimal precision
- Warning appears when penalty exceeds weight