### PR TITLE
Bump @cmusei/console-forge to 0.21.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@angular/platform-browser": "^19.2.14",
         "@angular/platform-browser-dynamic": "^19.2.14",
         "@angular/router": "^19.2.14",
-        "@cmusei/console-forge": "^0.21.4",
+        "@cmusei/console-forge": "^0.21.5",
         "@fortawesome/angular-fontawesome": "^1.0.0",
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
         "@fortawesome/free-brands-svg-icons": "^6.2.1",
@@ -2405,9 +2405,9 @@
       "optional": true
     },
     "node_modules/@cmusei/console-forge": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/@cmusei/console-forge/-/console-forge-0.21.4.tgz",
-      "integrity": "sha512-yjIxeMbmJB6NT9XXD4zpDwbezAxzaGo2uJMa/GUQggSB15WrN7s9sutNILAiJmkr9iE4eIoY+I3WV2xBmek7zQ==",
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@cmusei/console-forge/-/console-forge-0.21.5.tgz",
+      "integrity": "sha512-xIfVw+nrP+xlZZIL6HM4M3vb8rBSJPlEbQmegQCnJkDI1voeJ7IV5AOlwt6Jg6ExhKb7uhg4OTnHpZ0EHyn/XA==",
       "dependencies": {
         "@picocss/pico": "^2.1.1",
         "tslib": "^2.3.0"
@@ -2415,7 +2415,7 @@
       "peerDependencies": {
         "@angular/common": ">=19.2.0",
         "@angular/core": ">=19.2.0",
-        "@novnc/novnc": "^1.4.0"
+        "@novnc/novnc": ">=1.4.0 <1.6.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^19.2.14",
     "@angular/platform-browser-dynamic": "^19.2.14",
     "@angular/router": "^19.2.14",
-    "@cmusei/console-forge": "^0.21.4",
+    "@cmusei/console-forge": "^0.21.5",
     "@fortawesome/angular-fontawesome": "^1.0.0",
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-brands-svg-icons": "^6.2.1",


### PR DESCRIPTION
## Summary

Picks up [ConsoleForge 0.21.5](https://github.com/cmu-sei/console-forge/pull/23), which fixes VNC/Proxmox VM consoles failing to open.

On 0.21.4, opening any VNC console threw immediately:

```
TypeError: import_rfb.default is not a constructor
```

ConsoleForge surfaced this as a generic "Connection error", so it looked like a network or hypervisor problem. In fact the noVNC client was throwing during *construction*, before any connection was attempted — ConsoleForge's ESM bundle did a default import of noVNC's CommonJS build, and under ESM→CJS interop the RFB constructor lands one level deeper than the type claims.

## User-facing changes

- Proxmox VM consoles open and connect again.

## Technical details

`@cmusei/console-forge` `^0.21.4` → `^0.21.5`; lockfile regenerated.

`@novnc/novnc` stays at `~1.5.0`. ConsoleForge 0.21.5 narrowed its peer range to `>=1.4.0 <1.6.0`, which `~1.5.0` satisfies, so no change is needed here.